### PR TITLE
[mini-PR] fix some warnings related to unnecessary ";"

### DIFF
--- a/src/multi_physics/QED/src/containers/picsar_tables.hpp
+++ b/src/multi_physics/QED/src/containers/picsar_tables.hpp
@@ -50,13 +50,13 @@ namespace containers{
                 m_how_many_x = static_cast<int>(values.size());
                 m_x_size = x_max - x_min;
                 m_dx = m_x_size/(m_how_many_x-1);
-            };
+            }
 
         /**
         * Empty constructor
         */
         PXRMP_INTERNAL_GPU_DECORATOR PXRMP_INTERNAL_FORCE_INLINE_DECORATOR
-        equispaced_1d_table(){};
+        equispaced_1d_table(){}
 
         /**
         * Constructor from byte array (not usable on GPUs)
@@ -99,7 +99,7 @@ namespace containers{
             auto vals =
                 serialization::get_n_out<RealType>(it_raw_data, m_how_many_x);
             std::copy(vals.begin(), vals.end(), m_values.begin());
-        };
+        }
 
         /**
         * Operator ==
@@ -334,13 +334,13 @@ namespace containers{
                 m_y_size = y_max - y_min;
                 m_dx = m_x_size/(m_how_many_x-1);
                 m_dy = m_y_size/(m_how_many_y-1);
-            };
+            }
 
         /**
         * Empty constructor
         */
         PXRMP_INTERNAL_GPU_DECORATOR PXRMP_INTERNAL_FORCE_INLINE_DECORATOR
-        equispaced_2d_table(){};
+        equispaced_2d_table(){}
 
         /**
         * Constructor from byte array (not usable on GPUs)
@@ -397,7 +397,7 @@ namespace containers{
                     it_raw_data,
                     m_how_many_x*m_how_many_y);
             std::copy(vals.begin(), vals.end(), m_values.begin());
-        };
+        }
 
         /**
         * Operator ==

--- a/src/multi_physics/QED/src/physics/breit_wheeler/breit_wheeler_engine_tables.hpp
+++ b/src/multi_physics/QED/src/physics/breit_wheeler/breit_wheeler_engine_tables.hpp
@@ -190,7 +190,7 @@ namespace breit_wheeler{
             /**
             * Empty constructor (not designed for GPU)
             **/
-            dndt_lookup_table(){};
+            dndt_lookup_table(){}
 
             /**
             * Constructor (not designed for GPU)
@@ -206,7 +206,7 @@ namespace breit_wheeler{
                     math::m_log(params.chi_phot_min),
                     math::m_log(params.chi_phot_max),
                     VectorType(params.chi_phot_how_many)}}
-            {};
+            {}
 
             /**
             * Constructor (not designed for GPU)
@@ -225,7 +225,7 @@ namespace breit_wheeler{
                     vals}}
             {
                 m_init_flag = true;
-            };
+            }
 
             /*
             * Generates the content of the lookup table (not usable on GPUs).
@@ -273,7 +273,7 @@ namespace breit_wheeler{
                         raw_data.end())};
 
                 m_init_flag = true;
-            };
+            }
 
             /**
             * Operator==
@@ -525,7 +525,7 @@ namespace breit_wheeler{
             /**
             * Empty constructor (not designed for GPU usage)
             */
-            pair_prod_lookup_table(){};
+            pair_prod_lookup_table(){}
 
 
             /**
@@ -545,7 +545,7 @@ namespace breit_wheeler{
                     math::half<RealType>,
                     params.chi_phot_how_many, params.frac_how_many,
                     VectorType(params.chi_phot_how_many * params.frac_how_many)}}
-                {};
+                {}
 
             /**
             * Constructor (not designed for GPU)
@@ -567,7 +567,7 @@ namespace breit_wheeler{
                         vals}}
             {
                 m_init_flag = true;
-            };
+            }
 
             /*
             * Generates the content of the lookup table (not usable on GPUs).
@@ -615,7 +615,7 @@ namespace breit_wheeler{
                     raw_data.end())};
 
                 m_init_flag = true;
-            };
+            }
 
             /**
             * Operator==

--- a/src/multi_physics/QED/src/physics/quantum_sync/quantum_sync_engine_tables.hpp
+++ b/src/multi_physics/QED/src/physics/quantum_sync/quantum_sync_engine_tables.hpp
@@ -145,7 +145,7 @@ namespace quantum_sync{
             /**
             * Empty constructor (not designed for GPU)
             **/
-            dndt_lookup_table(){};
+            dndt_lookup_table(){}
 
             /**
             * Constructor (not designed for GPU usage)
@@ -160,7 +160,7 @@ namespace quantum_sync{
                     math::m_log(params.chi_part_min),
                     math::m_log(params.chi_part_max),
                     VectorType(params.chi_part_how_many)}}
-            {};
+            {}
 
             /**
             * Constructor (not designed for GPU usage)
@@ -179,7 +179,7 @@ namespace quantum_sync{
                     vals}}
             {
                 m_init_flag = true;
-            };
+            }
 
             /*
             * Generates the content of the lookup table (not usable on GPUs).
@@ -227,7 +227,7 @@ namespace quantum_sync{
                         raw_data.end())};
 
                 m_init_flag = true;
-            };
+            }
 
             /**
             * Operator==
@@ -476,7 +476,7 @@ namespace quantum_sync{
             /**
             * Empty constructor (not designed for GPU usage)
             */
-            photon_emission_lookup_table(){};
+            photon_emission_lookup_table(){}
 
             /**
             * Constructor (not designed for GPU usage)
@@ -495,7 +495,7 @@ namespace quantum_sync{
                     math::m_log(math::one<RealType>),
                     params.chi_part_how_many, params.frac_how_many,
                     VectorType(params.chi_part_how_many * params.frac_how_many)}}
-                {};
+                {}
 
             /**
             * Constructor (not designed for GPU usage)
@@ -517,7 +517,7 @@ namespace quantum_sync{
                     vals}}
             {
                 m_init_flag = true;
-            };
+            }
 
             /*
             * Generates the content of the lookup table (not usable on GPUs).
@@ -565,7 +565,7 @@ namespace quantum_sync{
                     raw_data.end())};
 
                 m_init_flag = true;
-            };
+            }
 
             /**
             * Operator==


### PR DESCRIPTION
This PR fixes some other warnings related to unnecessary ";"  at the end of method definitions.
I have verified that with these changes the automated tests succeed and WarpX can be successfully compiled. 