### PR TITLE
Add floor to cmath overloads

### DIFF
--- a/src/multi_physics/QED/src/containers/picsar_tables.hpp
+++ b/src/multi_physics/QED/src/containers/picsar_tables.hpp
@@ -11,6 +11,8 @@
 #include "../utils/serialization.hpp"
 // Some mathematical constants are used
 #include "../math/math_constants.h"
+//Uses floor
+#include "../math/cmath_overloads.hpp"
 
 #include <vector>
 #include <array>
@@ -235,8 +237,10 @@ namespace containers{
         PXRMP_INTERNAL_GPU_DECORATOR PXRMP_INTERNAL_FORCE_INLINE_DECORATOR
         RealType interp(const RealType where_x) const noexcept
         {
+            using namespace picsar::multi_physics::math;
+
             const auto idx_left = static_cast<int>(
-                floor((m_how_many_x-1)*(where_x-m_x_min)/m_x_size));
+                m_floor((m_how_many_x-1)*(where_x-m_x_min)/m_x_size));
             if (idx_left == (m_how_many_x-1))
                 return  m_values[m_how_many_x-1];
             const auto idx_right = idx_left + 1;
@@ -611,13 +615,15 @@ namespace containers{
         PXRMP_INTERNAL_GPU_DECORATOR PXRMP_INTERNAL_FORCE_INLINE_DECORATOR
         RealType interp(const RealType where_x, const RealType where_y) const noexcept
         {
+            using namespace picsar::multi_physics::math;
+
             auto idx_x_left = static_cast<int>(
-                floor((m_how_many_x-1)*(where_x-m_x_min)/m_x_size));
+                m_floor((m_how_many_x-1)*(where_x-m_x_min)/m_x_size));
             if (idx_x_left == (m_how_many_x-1))
                 idx_x_left = m_how_many_x-2;
             const auto idx_x_right = idx_x_left + 1;
             auto idx_y_left = static_cast<int>(
-                floor((m_how_many_y-1)*(where_y-m_y_min)/m_y_size));
+                m_floor((m_how_many_y-1)*(where_y-m_y_min)/m_y_size));
             if (idx_y_left == (m_how_many_y-1))
                 idx_y_left = m_how_many_y-2;
             const auto idx_y_right = idx_y_left + 1;
@@ -649,8 +655,10 @@ namespace containers{
         PXRMP_INTERNAL_GPU_DECORATOR PXRMP_INTERNAL_FORCE_INLINE_DECORATOR
         RealType interp_first_coord(RealType where_x, int j) const noexcept
         {
+            using namespace picsar::multi_physics::math;
+
             auto idx_left = static_cast<int>(
-                floor((m_how_many_x-1)*(where_x-m_x_min)/m_x_size));
+                m_floor((m_how_many_x-1)*(where_x-m_x_min)/m_x_size));
             if (idx_left == (m_how_many_x-1))
                 idx_left = m_how_many_x-2;
             const auto idx_right = idx_left + 1;
@@ -675,8 +683,10 @@ namespace containers{
         PXRMP_INTERNAL_GPU_DECORATOR PXRMP_INTERNAL_FORCE_INLINE_DECORATOR
         RealType interp_second_coord(int i, RealType where_y) const noexcept
         {
+            using namespace picsar::multi_physics::math;
+
             auto idx_left = static_cast<int>(
-                floor((m_how_many_y-1)*(where_y-m_y_min)/m_y_size));
+                m_floor((m_how_many_y-1)*(where_y-m_y_min)/m_y_size));
             if (idx_left == (m_how_many_y-1))
                 idx_left = m_how_many_y-2;
             const auto idx_right = idx_left + 1;

--- a/src/multi_physics/QED/src/math/cmath_overloads.hpp
+++ b/src/multi_physics/QED/src/math/cmath_overloads.hpp
@@ -177,7 +177,7 @@ namespace math{
     *
     * @tparam RealType the floating point type to be used
     * @param[in] x argument
-    * @return the exponential of x
+    * @return the floor of x
     */
     template<typename RealType>
     PXRMP_INTERNAL_GPU_DECORATOR PXRMP_INTERNAL_FORCE_INLINE_DECORATOR

--- a/src/multi_physics/QED/src/math/cmath_overloads.hpp
+++ b/src/multi_physics/QED/src/math/cmath_overloads.hpp
@@ -145,7 +145,7 @@ namespace math{
     *
     * @tparam RealType the floating point type to be used
     * @param[in] x argument
-    * @return the exponential of x
+    * @return tanh of x
     */
     template<typename RealType>
     PXRMP_INTERNAL_GPU_DECORATOR PXRMP_INTERNAL_FORCE_INLINE_DECORATOR
@@ -166,6 +166,38 @@ namespace math{
     float m_tanh(const float x) noexcept
     {
         return tanhf(x);
+    }
+
+    //________________________________________________________
+
+    /**
+    * This function replaces the overload of floor provided
+    * by the Standard Template Library. It calls either
+    * floor or floorf in cmath depending on the variable type.
+    *
+    * @tparam RealType the floating point type to be used
+    * @param[in] x argument
+    * @return the exponential of x
+    */
+    template<typename RealType>
+    PXRMP_INTERNAL_GPU_DECORATOR PXRMP_INTERNAL_FORCE_INLINE_DECORATOR
+    RealType m_floor(const RealType x) noexcept
+    {
+        return floor(x);
+    }
+
+    template<>
+    PXRMP_INTERNAL_GPU_DECORATOR PXRMP_INTERNAL_FORCE_INLINE_DECORATOR
+    double m_floor(const double x) noexcept
+    {
+        return floor(x);
+    }
+
+    template<>
+    PXRMP_INTERNAL_GPU_DECORATOR PXRMP_INTERNAL_FORCE_INLINE_DECORATOR
+    float m_floor(const float x) noexcept
+    {
+        return floorf(x);
     }
 
 }

--- a/src/multi_physics/QED_tests/test_picsar_cmath_overload.cpp
+++ b/src/multi_physics/QED_tests/test_picsar_cmath_overload.cpp
@@ -33,6 +33,14 @@ void test_case_cmath_overloads()
         BOOST_CHECK_EQUAL(m_tanh(val), std::tanh(val));
         BOOST_CHECK_EQUAL(m_tanh(-val), std::tanh(-val));
      }
+
+     const auto vals_floor = std::vector<RealType>{0.0, 0.001, 0.3, 0.7,
+         1.11, 1.5, 1.55, 20.9, 100.56, 1000.24};
+
+    for (const auto val : vals_floor){
+        BOOST_CHECK_EQUAL(m_floor(val), std::floor(val));
+        BOOST_CHECK_EQUAL(m_floor(-val), std::floor(-val));
+    }
 }
 
 BOOST_AUTO_TEST_CASE( picsar_cmath_overloads )

--- a/src/multi_physics/QED_tests/test_picsar_cmath_overload.cpp
+++ b/src/multi_physics/QED_tests/test_picsar_cmath_overload.cpp
@@ -34,7 +34,7 @@ void test_case_cmath_overloads()
         BOOST_CHECK_EQUAL(m_tanh(-val), std::tanh(-val));
      }
 
-     const auto vals_floor = std::vector<RealType>{0.0, 0.001, 0.3, 0.7,
+    const auto vals_floor = std::vector<RealType>{0.0, 0.001, 0.3, 0.7,
          1.11, 1.5, 1.55, 20.9, 100.56, 1000.24};
 
     for (const auto val : vals_floor){


### PR DESCRIPTION
`floor` was not among the functions included in `cmath_overloads.hpp`. This PR fixes the issue.