### PR TITLE
Fix GPU error cross-execution-space-call

### DIFF
--- a/src/multi_physics/QED/src/physics/breit_wheeler/breit_wheeler_engine_tables.hpp
+++ b/src/multi_physics/QED/src/physics/breit_wheeler/breit_wheeler_engine_tables.hpp
@@ -188,8 +188,9 @@ namespace breit_wheeler{
                 RealType, containers::picsar_span<const RealType>> view_type;
 
             /**
-            * Empty constructor (not designed for GPU)
+            * Empty constructor
             **/
+            PXRMP_INTERNAL_GPU_DECORATOR PXRMP_INTERNAL_FORCE_INLINE_DECORATOR
             dndt_lookup_table(){}
 
             /**
@@ -523,8 +524,9 @@ namespace breit_wheeler{
                 RealType, containers::picsar_span<const RealType>> view_type;
 
             /**
-            * Empty constructor (not designed for GPU usage)
+            * Empty constructor
             */
+            PXRMP_INTERNAL_GPU_DECORATOR PXRMP_INTERNAL_FORCE_INLINE_DECORATOR
             pair_prod_lookup_table(){}
 
 

--- a/src/multi_physics/QED/src/physics/quantum_sync/quantum_sync_engine_tables.hpp
+++ b/src/multi_physics/QED/src/physics/quantum_sync/quantum_sync_engine_tables.hpp
@@ -143,8 +143,9 @@ namespace quantum_sync{
                 RealType, containers::picsar_span<const RealType>> view_type;
 
             /**
-            * Empty constructor (not designed for GPU)
+            * Empty constructor
             **/
+            PXRMP_INTERNAL_GPU_DECORATOR PXRMP_INTERNAL_FORCE_INLINE_DECORATOR
             dndt_lookup_table(){}
 
             /**
@@ -474,8 +475,9 @@ namespace quantum_sync{
                 RealType, containers::picsar_span<const RealType>> view_type;
 
             /**
-            * Empty constructor (not designed for GPU usage)
+            * Empty constructor
             */
+            PXRMP_INTERNAL_GPU_DECORATOR PXRMP_INTERNAL_FORCE_INLINE_DECORATOR
             photon_emission_lookup_table(){}
 
             /**


### PR DESCRIPTION
Since https://github.com/AMReX-Codes/amrex/pull/1540 in AMREX, cross-execution-space-call is an error. This results in a failure when WarpX is compiled with QED support, due to a bug in PICSAR. This PR should fix the issue.
