### PR TITLE
Truly fix cross execution errors

### DIFF
--- a/src/multi_physics/QED/src/containers/picsar_tables.hpp
+++ b/src/multi_physics/QED/src/containers/picsar_tables.hpp
@@ -762,8 +762,8 @@ namespace containers{
             RealType m_y_size = static_cast<RealType>(0.0); /* size along y */
             int m_how_many_x = 0; /* how many grid points along x */
             int m_how_many_y = 0; /* how many grid points along y */
-            RealType m_dx = static_cast<RealType>(0.0);; /* step size along x */
-            RealType m_dy = static_cast<RealType>(0.0);; /* step size along y */
+            RealType m_dx = static_cast<RealType>(0.0); /* step size along x */
+            RealType m_dy = static_cast<RealType>(0.0); /* step size along y */
             VectorType m_values; /* values f(x,y) */
 
         /**

--- a/src/multi_physics/QED/src/containers/picsar_tables.hpp
+++ b/src/multi_physics/QED/src/containers/picsar_tables.hpp
@@ -57,7 +57,7 @@ namespace containers{
         /**
         * Empty constructor
         */
-        PXRMP_INTERNAL_GPU_DECORATOR PXRMP_INTERNAL_FORCE_INLINE_DECORATOR
+        constexpr
         equispaced_1d_table(){}
 
         /**
@@ -289,11 +289,11 @@ namespace containers{
         }
 
     protected:
-        RealType m_x_min = 0.0; /* minimum x coordinate */
-        RealType m_x_max = 0.0; /* maximum x coordinate */
-        RealType m_x_size = 0.0; /* size along x */
+        RealType m_x_min = static_cast<RealType>(0.0); /* minimum x coordinate */
+        RealType m_x_max = static_cast<RealType>(0.0);/* maximum x coordinate */
+        RealType m_x_size = static_cast<RealType>(0.0); /* size along x */
         int m_how_many_x = 0; /* how many values are stored in the table */
-        RealType m_dx = 0.0; /* size of the step along x */
+        RealType m_dx = static_cast<RealType>(0.0); /* size of the step along x */
         VectorType m_values; /* values f(x) */
     };
 
@@ -343,7 +343,7 @@ namespace containers{
         /**
         * Empty constructor
         */
-        PXRMP_INTERNAL_GPU_DECORATOR PXRMP_INTERNAL_FORCE_INLINE_DECORATOR
+        constexpr
         equispaced_2d_table(){}
 
         /**
@@ -754,16 +754,16 @@ namespace containers{
 
     protected:
 
-            RealType m_x_min; /* minimum x coordinate */
-            RealType m_x_max; /* maximum x coordinate */
-            RealType m_y_min; /* minimum y coordinate */
-            RealType m_y_max; /* maximum y coordinate */
-            RealType m_x_size; /* size along x */
-            RealType m_y_size; /* size along y */
-            int m_how_many_x; /* how many grid points along x */
-            int m_how_many_y; /* how many grid points along y */
-            RealType m_dx; /* step size along x */
-            RealType m_dy; /* step size along y */
+            RealType m_x_min = static_cast<RealType>(0.0); /* minimum x coordinate */
+            RealType m_x_max = static_cast<RealType>(0.0); /* maximum x coordinate */
+            RealType m_y_min = static_cast<RealType>(0.0); /* minimum y coordinate */
+            RealType m_y_max = static_cast<RealType>(0.0); /* maximum y coordinate */
+            RealType m_x_size = static_cast<RealType>(0.0); /* size along x */
+            RealType m_y_size = static_cast<RealType>(0.0); /* size along y */
+            int m_how_many_x = 0; /* how many grid points along x */
+            int m_how_many_y = 0; /* how many grid points along y */
+            RealType m_dx = static_cast<RealType>(0.0);; /* step size along x */
+            RealType m_dy = static_cast<RealType>(0.0);; /* step size along y */
             VectorType m_values; /* values f(x,y) */
 
         /**

--- a/src/multi_physics/QED/src/physics/breit_wheeler/breit_wheeler_engine_tables.hpp
+++ b/src/multi_physics/QED/src/physics/breit_wheeler/breit_wheeler_engine_tables.hpp
@@ -65,9 +65,9 @@ namespace breit_wheeler{
     */
     template<typename RealType>
     struct dndt_lookup_table_params{
-        RealType chi_phot_min; /*Minimum photon chi parameter*/
-        RealType chi_phot_max;/*Maximum photon chi parameter*/
-        int chi_phot_how_many; /* Number of grid points for photon chi */
+        RealType chi_phot_min = static_cast<RealType>(0.0);/*Minimum photon chi parameter*/
+        RealType chi_phot_max = static_cast<RealType>(0.0);/*Maximum photon chi parameter*/
+        int chi_phot_how_many = 0; /* Number of grid points for photon chi */
 
         /**
         * Operator==
@@ -190,7 +190,7 @@ namespace breit_wheeler{
             /**
             * Empty constructor
             **/
-            PXRMP_INTERNAL_GPU_DECORATOR PXRMP_INTERNAL_FORCE_INLINE_DECORATOR
+            constexpr
             dndt_lookup_table(){}
 
             /**
@@ -450,10 +450,10 @@ namespace breit_wheeler{
     */
     template<typename RealType>
     struct pair_prod_lookup_table_params{
-        RealType chi_phot_min; /*Minimum photon chi parameter*/
-        RealType chi_phot_max; /*Maximum photon chi parameter*/
-        int chi_phot_how_many; /* Number of grid points for photon chi */
-        int frac_how_many; /* Number of grid points for particle chi fraction */
+        RealType chi_phot_min = static_cast<RealType>(0.0); /*Minimum photon chi parameter*/
+        RealType chi_phot_max = static_cast<RealType>(0.0); /*Maximum photon chi parameter*/
+        int chi_phot_how_many = 0; /* Number of grid points for photon chi */
+        int frac_how_many = 0; /* Number of grid points for particle chi fraction */
 
         /**
         * Operator==
@@ -526,7 +526,7 @@ namespace breit_wheeler{
             /**
             * Empty constructor
             */
-            PXRMP_INTERNAL_GPU_DECORATOR PXRMP_INTERNAL_FORCE_INLINE_DECORATOR
+            constexpr
             pair_prod_lookup_table(){}
 
 

--- a/src/multi_physics/QED/src/physics/quantum_sync/quantum_sync_engine_tables.hpp
+++ b/src/multi_physics/QED/src/physics/quantum_sync/quantum_sync_engine_tables.hpp
@@ -66,9 +66,9 @@ namespace quantum_sync{
     */
     template<typename RealType>
     struct dndt_lookup_table_params{
-        RealType chi_part_min; /*Minimum particle chi parameter*/
-        RealType chi_part_max; /*Maximum particle chi parameter*/
-        int chi_part_how_many; /* Number of grid points for particle chi */
+        RealType chi_part_min = static_cast<RealType>(0.0); /*Minimum particle chi parameter*/
+        RealType chi_part_max = static_cast<RealType>(0.0);; /*Maximum particle chi parameter*/
+        int chi_part_how_many = 0; /* Number of grid points for particle chi */
 
         /**
         * Operator==
@@ -145,7 +145,7 @@ namespace quantum_sync{
             /**
             * Empty constructor
             **/
-            PXRMP_INTERNAL_GPU_DECORATOR PXRMP_INTERNAL_FORCE_INLINE_DECORATOR
+            constexpr
             dndt_lookup_table(){}
 
             /**
@@ -401,11 +401,11 @@ namespace quantum_sync{
     */
     template<typename RealType>
     struct photon_emission_lookup_table_params{
-        RealType chi_part_min; /*Minimum particle chi parameter*/
-        RealType chi_part_max; /*Maximum particle chi parameter*/
-        RealType frac_min; /*Minimum chi photon fraction to be stored*/
-        int chi_part_how_many; /* Number of grid points for particle chi */
-        int frac_how_many; /* Number of grid points for photon chi fraction */
+        RealType chi_part_min = static_cast<RealType>(0.0); /*Minimum particle chi parameter*/
+        RealType chi_part_max = static_cast<RealType>(0.0); /*Maximum particle chi parameter*/
+        RealType frac_min = static_cast<RealType>(0.0); /*Minimum chi photon fraction to be stored*/
+        int chi_part_how_many = 0; /* Number of grid points for particle chi */
+        int frac_how_many = 0; /* Number of grid points for photon chi fraction */
 
         /**
         * Operator==
@@ -477,7 +477,7 @@ namespace quantum_sync{
             /**
             * Empty constructor
             */
-            PXRMP_INTERNAL_GPU_DECORATOR PXRMP_INTERNAL_FORCE_INLINE_DECORATOR
+            constexpr
             photon_emission_lookup_table(){}
 
             /**

--- a/src/multi_physics/QED/src/physics/quantum_sync/quantum_sync_engine_tables.hpp
+++ b/src/multi_physics/QED/src/physics/quantum_sync/quantum_sync_engine_tables.hpp
@@ -67,7 +67,7 @@ namespace quantum_sync{
     template<typename RealType>
     struct dndt_lookup_table_params{
         RealType chi_part_min = static_cast<RealType>(0.0); /*Minimum particle chi parameter*/
-        RealType chi_part_max = static_cast<RealType>(0.0);; /*Maximum particle chi parameter*/
+        RealType chi_part_max = static_cast<RealType>(0.0); /*Maximum particle chi parameter*/
         int chi_part_how_many = 0; /* Number of grid points for particle chi */
 
         /**

--- a/src/multi_physics/QED/src/utils/serialization.hpp
+++ b/src/multi_physics/QED/src/utils/serialization.hpp
@@ -18,17 +18,17 @@ namespace serialization{
     /**
     * This function transform a variable of type T into a vector of chars holding its
     * byte representation and it appends this vector at the end of an
-    * existing vector of chars. T must be a POD type. This functions is not
+    * existing vector of chars. T must be a trivially copyable type. This functions is not
     * usable on GPUs.
     *
-    * @tparam T the variable type (must be POD)
+    * @tparam T the variable type (must be trivially copyable)
     * @param[in, out] vec a reference to the vector to which the byte representation of val is appended
     */
     template<typename T>
     inline void put_in(T val, std::vector<char>& vec)
     {
-        static_assert(std::is_pod<T>(), "Cannot serialize \
-            non-POD types.");
+        static_assert(std::is_trivially_copyable<T>(), "Cannot serialize \
+            non-trivally copyable types.");
 
         const auto* ptr_val = reinterpret_cast<char*>(&val);
         vec.insert(vec.end(), ptr_val, ptr_val+sizeof(T));
@@ -37,10 +37,10 @@ namespace serialization{
     /**
     * This function extract a variable of type T from a byte vector, at the position
     * given by an iterator. The iterator is then advanced according to
-    * the number of bytes read from the byte vector. T must be a POD type.
+    * the number of bytes read from the byte vector. T must be a trivially copyable type.
     * This functions is not usable on GPUs.
     *
-    * @tparam T the variable type (must be POD)
+    * @tparam T the variable type (must be trivially copyable)
     * @tparam CharIter the iterator type
     * @param[in, out] it the iterator to a byte vector
     * @return the variable extracted from the byte array
@@ -48,8 +48,8 @@ namespace serialization{
     template<typename T, typename CharIter=std::vector<char>::const_iterator>
     inline T get_out(CharIter& it)
     {
-        static_assert(std::is_pod<T>(), "Cannot extract \
-            non-POD types from char vectors.");
+        static_assert(std::is_trivially_copyable<T>(), "Cannot extract \
+            non-trivally copyable types from char vectors.");
 
         auto temp = std::array<char, sizeof(T)>{};
         std::copy(it, it + sizeof(T), temp.begin());
@@ -62,10 +62,10 @@ namespace serialization{
     /**
     * This function extract several variables of type T from a byte vector,
     * at the position given by an iterator. The iterator is then advanced according to
-    * the number of bytes read from the byte vector. T must be a POD type.
+    * the number of bytes read from the byte vector. T must be a trivially copyable type.
     * This functions is not usable on GPUs.
     *
-    * @tparam T the variable type (must be POD)
+    * @tparam T the variable type (must be trivially copyable)
     * @tparam CharIter the iterator type
     * @param[in, out] it the iterator to a byte vector
     * @param[in] how_many how many variables should be extracted
@@ -76,8 +76,8 @@ namespace serialization{
         CharIter& it,
         int how_many)
     {
-        static_assert(std::is_pod<T>(), "Cannot extract \
-            non-POD types from char vectors.");
+        static_assert(std::is_trivially_copyable<T>(), "Cannot extract \
+            non-trivally copyable types from char vectors.");
 
         auto res = std::vector<T>(how_many);
         std::generate(res.begin(), res.end(),


### PR DESCRIPTION
This PR should really fix the issue with cross execution errors.
Now empty constructors are `constexpr`, which makes them callable from `__device__` functions. 
Making these functions `constexpr` forced me to assign default values to some parameters. This was straightforward, but, as a side effect, it turned some structs to `non-POD` types. For this reason I had to change the test `is_POD` in `serialization.hpp` to `is_trivially_copyable` (which is actually more appropriate).

With these additions, `WarpX` with QED support compiles on Summit.
