### PR TITLE
Fix issues related to double --> float conversions

### DIFF
--- a/src/multi_physics/QED/src/math/cmath_overloads.hpp
+++ b/src/multi_physics/QED/src/math/cmath_overloads.hpp
@@ -10,6 +10,115 @@ namespace picsar{
 namespace multi_physics{
 namespace math{
 
+#ifdef PXRMP_INTERNAL_USE_STD_FOR_MATH
+
+    /**
+    * This function wraps the overload of sqrt provided
+    * by the Standard Template Library.
+    *
+    * @tparam RealType the floating point type to be used
+    * @param[in] x argument
+    * @return the square root of x
+    */
+    template<typename RealType>
+    PXRMP_INTERNAL_GPU_DECORATOR PXRMP_INTERNAL_FORCE_INLINE_DECORATOR
+    RealType m_sqrt(const RealType x) noexcept
+    {
+        return std::sqrt(x);
+    }
+
+    /**
+    * This function wraps the overload of cbrt provided
+    * by the Standard Template Library.
+    *
+    * @tparam RealType the floating point type to be used
+    * @param[in] x argument
+    * @return the cubic root of x
+    */
+    template<typename RealType>
+    PXRMP_INTERNAL_GPU_DECORATOR PXRMP_INTERNAL_FORCE_INLINE_DECORATOR
+    RealType m_cbrt(const RealType x) noexcept
+    {
+        return std::cbrt(x);
+    }
+
+    /**
+    * This function wraps the overload of log provided
+    * by the Standard Template Library.
+    *
+    * @tparam RealType the floating point type to be used
+    * @param[in] x argument
+    * @return the log of x
+    */
+    template<typename RealType>
+    PXRMP_INTERNAL_GPU_DECORATOR PXRMP_INTERNAL_FORCE_INLINE_DECORATOR
+    RealType m_log(const RealType x) noexcept
+    {
+        return std::log(x);
+    }
+
+    /**
+    * This function wraps the overload of exp provided
+    * by the Standard Template Library.
+    *
+    * @tparam RealType the floating point type to be used
+    * @param[in] x argument
+    * @return the exponential of x
+    */
+    template<typename RealType>
+    PXRMP_INTERNAL_GPU_DECORATOR PXRMP_INTERNAL_FORCE_INLINE_DECORATOR
+    RealType m_exp(const RealType x) noexcept
+    {
+        return std::exp(x);
+    }
+
+    /**
+    * This function wraps the overload of tanh provided
+    * by the Standard Template Library.
+    *
+    * @tparam RealType the floating point type to be used
+    * @param[in] x argument
+    * @return tanh of x
+    */
+    template<typename RealType>
+    PXRMP_INTERNAL_GPU_DECORATOR PXRMP_INTERNAL_FORCE_INLINE_DECORATOR
+    RealType m_tanh(const RealType x) noexcept
+    {
+        return std::tanh(x);
+    }
+
+    /**
+    * This function wraps the overload of floor provided
+    * by the Standard Template Library.
+    *
+    * @tparam RealType the floating point type to be used
+    * @param[in] x argument
+    * @return the floor of x
+    */
+    template<typename RealType>
+    PXRMP_INTERNAL_GPU_DECORATOR PXRMP_INTERNAL_FORCE_INLINE_DECORATOR
+    RealType m_floor(const RealType x) noexcept
+    {
+        return std::floor(x);
+    }
+
+    /**
+    * This function wraps the overload of fabs provided
+    * by the Standard Template Library.
+    *
+    * @tparam RealType the floating point type to be used
+    * @param[in] x argument
+    * @return the fabs of x
+    */
+    template<typename RealType>
+    PXRMP_INTERNAL_GPU_DECORATOR PXRMP_INTERNAL_FORCE_INLINE_DECORATOR
+    RealType m_fabs(const RealType x) noexcept
+    {
+        return std::fabs(x);
+    }
+
+#else
+
     /**
     * This function replaces the overload of sqrt provided
     * by the Standard Template Library. It calls either
@@ -200,8 +309,41 @@ namespace math{
         return floorf(x);
     }
 
+    /**
+    * This function replaces the overload of fabs provided
+    * by the Standard Template Library. It calls either
+    * fabs or fabsf in cmath depending on the variable type.
+    *
+    * @tparam RealType the floating point type to be used
+    * @param[in] x argument
+    * @return the fabs of x
+    */
+    template<typename RealType>
+    PXRMP_INTERNAL_GPU_DECORATOR PXRMP_INTERNAL_FORCE_INLINE_DECORATOR
+    RealType m_fabs(const RealType x) noexcept
+    {
+        return fabs(x);
+    }
+
+    template<>
+    PXRMP_INTERNAL_GPU_DECORATOR PXRMP_INTERNAL_FORCE_INLINE_DECORATOR
+    double m_fabs(const double x) noexcept
+    {
+        return fabs(x);
+    }
+
+    template<>
+    PXRMP_INTERNAL_GPU_DECORATOR PXRMP_INTERNAL_FORCE_INLINE_DECORATOR
+    float m_fabs(const float x) noexcept
+    {
+        return fabsf(x);
+    }
+
+#endif
+
 }
 }
 }
+
 
 #endif //PICSAR_MULTIPHYSICS_CMATH_OVERLOADS

--- a/src/multi_physics/QED/src/physics/breit_wheeler/breit_wheeler_engine_tables.hpp
+++ b/src/multi_physics/QED/src/physics/breit_wheeler/breit_wheeler_engine_tables.hpp
@@ -46,9 +46,9 @@ namespace breit_wheeler{
     //Reasonable default values for the dndt_lookup_table_params
     //and the pair_prod_lookup_table_params (see below)
     template <typename T>
-    constexpr T default_chi_phot_min = 2.0e-2; /*Default minimum photon chi parameter*/
+    constexpr T default_chi_phot_min = static_cast<T>(2.0e-2); /*Default minimum photon chi parameter*/
     template <typename T>
-    constexpr T default_chi_phot_max = 1.0e3; /* Default maximum photon chi parameter*/
+    constexpr T default_chi_phot_max = static_cast<T>(1.0e3); /* Default maximum photon chi parameter*/
     const int default_chi_phot_how_many = 256; /* Default number of grid points for photon chi */
     const int default_frac_how_many = 256; /* Default number of grid points for particle chi */
 
@@ -103,9 +103,9 @@ namespace breit_wheeler{
 
     //Coefficients for che asymptotic behaviour of the T function
     template <typename T> //0.16*pi*(3/8)
-    constexpr T erber_dndt_asynt_a = 0.1884955592153876; /*Coefficient a of the Erber approximation*/
+    constexpr T erber_dndt_asynt_a = static_cast<T>(0.1884955592153876); /*Coefficient a of the Erber approximation*/
     template <typename T> //0.16*(gamma(1/3)*(3/2)**(1/3) /2)**2
-    constexpr T erber_dndt_asynt_b = 0.37616610710114734; /*Coefficient b of the Erber approximation*/
+    constexpr T erber_dndt_asynt_b = static_cast<T>(0.37616610710114734); /*Coefficient b of the Erber approximation*/
 
     /**
     * This function provides an approximation for the T function
@@ -120,7 +120,7 @@ namespace breit_wheeler{
     PXRMP_INTERNAL_FORCE_INLINE_DECORATOR
     RealType dndt_approx_left(RealType chi_phot)
     {
-        constexpr RealType coeff = 8./3.;
+        constexpr RealType coeff = static_cast<RealType>(8./3.);
         return erber_dndt_asynt_a<RealType>*math::m_exp(-coeff/chi_phot);
     }
 

--- a/src/multi_physics/QED/src/physics/chi_functions.hpp
+++ b/src/multi_physics/QED/src/physics/chi_functions.hpp
@@ -152,7 +152,7 @@ namespace phys{
         const auto beta_dot_e_2 = beta_dot_e*beta_dot_e;
         const auto e_plus_beta_cross_b_2 =
             norm_square(em_e + cross(beta_vec, em_b));
-        const auto field = m_sqrt(fabs(beta_dot_e_2-e_plus_beta_cross_b_2));
+        const auto field = m_sqrt(m_fabs(beta_dot_e_2-e_plus_beta_cross_b_2));
 
         constexpr auto one_over_schwinger = static_cast<RealType>(1.0/
             heaviside_lorentz_schwinger_field<double>);

--- a/src/multi_physics/QED/src/physics/quantum_sync/quantum_sync_engine_core.hpp
+++ b/src/multi_physics/QED/src/physics/quantum_sync/quantum_sync_engine_core.hpp
@@ -49,7 +49,7 @@ namespace quantum_sync{
     RealType get_optical_depth(const RealType unf_zero_one_minus_epsi)
     {
         using namespace math;
-        return -log(one<RealType> - unf_zero_one_minus_epsi);
+        return -m_log(one<RealType> - unf_zero_one_minus_epsi);
     }
 
     /**

--- a/src/multi_physics/QED/src/physics/quantum_sync/quantum_sync_engine_tables.hpp
+++ b/src/multi_physics/QED/src/physics/quantum_sync/quantum_sync_engine_tables.hpp
@@ -44,13 +44,13 @@ namespace quantum_sync{
     //Reasonable default values for the dndt_lookup_table_params
     //and the pair_prod_lookup_table_params (see below)
     template <typename T>
-    constexpr T default_chi_part_min = 1.0e-3; /*Default minimum particle chi parameter*/
+    constexpr T default_chi_part_min = static_cast<T>(1.0e-3); /*Default minimum particle chi parameter*/
     template <typename T>
-    constexpr T default_chi_part_max = 1.0e3; /* Default maximum particle chi parameter*/
+    constexpr T default_chi_part_max = static_cast<T>(1.0e3); /* Default maximum particle chi parameter*/
     const int default_chi_part_how_many = 256; /* Default number of grid points for particle chi */
     const int default_frac_how_many = 256; /* Default number of grid points for photon chi */
     template <typename T>
-    constexpr T default_frac_min = 1e-12; /* Default value of the minimum chi_photon fraction */
+    constexpr T default_frac_min = static_cast<T>(1e-12); /* Default value of the minimum chi_photon fraction */
 
     //__________________________________________________________________________
 

--- a/src/multi_physics/QED/src/qed_commons.h
+++ b/src/multi_physics/QED/src/qed_commons.h
@@ -120,4 +120,13 @@
     #define PXRMP_INTERNAL_CONSTEXPR_IF if
   #endif
 
+ /**
+ * Unless PXRMP_PREVENT_USE_STD_FOR_MATH is defined by the
+ * user, std::floor, std::sqrt, std::cbrt mathematical functions
+ * are used. 
+ */
+#ifndef PXRMP_PREVENT_USE_STD_FOR_MATH
+  #define PXRMP_INTERNAL_USE_STD_FOR_MATH
+#endif
+
 #endif// PICSAR_MULTIPHYSICS_QED_COMMONS

--- a/src/multi_physics/QED_tests/test_picsar_cmath_overload.cpp
+++ b/src/multi_physics/QED_tests/test_picsar_cmath_overload.cpp
@@ -10,6 +10,7 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/test/tools/floating_point_comparison.hpp>
 
+#define PXRMP_PREVENT_USE_STD_FOR_MATH
 #include "cmath_overloads.hpp"
 
 using namespace picsar::multi_physics::math;
@@ -34,12 +35,15 @@ void test_case_cmath_overloads()
         BOOST_CHECK_EQUAL(m_tanh(-val), std::tanh(-val));
      }
 
-    const auto vals_floor = std::vector<RealType>{0.0, 0.001, 0.3, 0.7,
+    const auto vals_floor_fabs = std::vector<RealType>{0.0, 0.001, 0.3, 0.7,
          1.11, 1.5, 1.55, 20.9, 100.56, 1000.24};
 
-    for (const auto val : vals_floor){
+    for (const auto val : vals_floor_fabs){
         BOOST_CHECK_EQUAL(m_floor(val), std::floor(val));
         BOOST_CHECK_EQUAL(m_floor(-val), std::floor(-val));
+
+        BOOST_CHECK_EQUAL(m_fabs(val), std::fabs(val));
+        BOOST_CHECK_EQUAL(m_fabs(-val), std::fabs(-val));
     }
 }
 


### PR DESCRIPTION
This PR fixes few issues related to conversions from `double` to `float`. Most of these issues are simply warnings, but in one case `fabs` was used instead of `m_fabs`, resulting in an unnecessary operation in double precision. To this regard, the way the code manages `m_*` functions (`m_sqrt`, `m_log` ...) has slightly changed. Now the default is to call the STL version (`std::sqrt`, `std::log` ...), since this is compatible with GPUs.   