### PR TITLE
DPCPP: Fix Warning (Double define)

### DIFF
--- a/multi_physics/QED/include/picsar_qed/qed_commons.h
+++ b/multi_physics/QED/include/picsar_qed/qed_commons.h
@@ -131,7 +131,9 @@
 */
 //
 #ifdef __SYCL_DEVICE_ONLY__
-    #define PXRMP_DPCPP_FIX
+#   ifndef PXRMP_DPCPP_FIX
+#       define PXRMP_DPCPP_FIX 1
+#   endif
 #endif
 
 /**


### PR DESCRIPTION
I saw a redefine warning in PICSAR with WarpX for the DPCPP work-around in CI:
```
/home/runner/work/WarpX/WarpX/build_sp/_deps/fetchedpicsar-src/multi_physics/QED/include/picsar_qed/qed_commons.h:134:13: warning: 'PXRMP_DPCPP_FIX' macro redefined [-Wmacro-redefined]
    #define PXRMP_DPCPP_FIX
            ^
<command line>:1:9: note: previous definition is here
        ^
```