### PR TITLE
[mini-PR] Fix misplaced using

### DIFF
--- a/multi_physics/QED/QED_tests/test_picsar_serialization.cpp
+++ b/multi_physics/QED/QED_tests/test_picsar_serialization.cpp
@@ -5,12 +5,12 @@
 
 #include <vector>
 
-using namespace picsar::multi_physics::utils::serialization;
-
 //Include Boost unit tests library
 #include <boost/test/unit_test.hpp>
 
 #include <picsar_qed/utils/serialization.hpp>
+
+using namespace picsar::multi_physics::utils::serialization;
 
 // ------------- Tests --------------
 


### PR DESCRIPTION
This PR fixes a misplaced `using` (it was placed **before** the inclusion of picsar header!)