### PR TITLE
[mini-PR] mark pure getters as const

### DIFF
--- a/multi_physics/QED/include/picsar_qed/physics/breit_wheeler/breit_wheeler_engine_tables.hpp
+++ b/multi_physics/QED/include/picsar_qed/physics/breit_wheeler/breit_wheeler_engine_tables.hpp
@@ -392,7 +392,7 @@ namespace breit_wheeler{
             */
             PXRMP_GPU_QUALIFIER
             PXRMP_FORCE_INLINE
-            bool is_init()
+            bool is_init() const
             {
                 return m_init_flag;
             }
@@ -778,7 +778,7 @@ namespace breit_wheeler{
             */
             PXRMP_GPU_QUALIFIER
             PXRMP_FORCE_INLINE
-            bool is_init()
+            bool is_init() const
             {
                 return m_init_flag;
             }

--- a/multi_physics/QED/include/picsar_qed/physics/quantum_sync/quantum_sync_engine_tables.hpp
+++ b/multi_physics/QED/include/picsar_qed/physics/quantum_sync/quantum_sync_engine_tables.hpp
@@ -341,7 +341,7 @@ namespace quantum_sync{
             */
             PXRMP_GPU_QUALIFIER
             PXRMP_FORCE_INLINE
-            bool is_init()
+            bool is_init() const
             {
                 return m_init_flag;
             }
@@ -730,7 +730,7 @@ namespace quantum_sync{
             */
             PXRMP_GPU_QUALIFIER
             PXRMP_FORCE_INLINE
-            bool is_init()
+            bool is_init() const
             {
                 return m_init_flag;
             }


### PR DESCRIPTION
This PR marks few methods as `const`, since they do not modify any member variable.