### PR TITLE
fix compilation issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ CC=mpicc
 CPP=mpic++
 
 # Fortran compiler arguments
-FARGS= -g -fbounds-check -O3 -fopenmp -JModules
+FARGS= -g -fbounds-check -O3 -fopenmp -JModules -fallow-argument-mismatch
 # C compiler Arguments
 CARGS= -g -O3 -fopenmp
 # C++ compiler Arguments
@@ -258,34 +258,34 @@ ifeq ($(COMP),gnu)
 
   ifeq ($(MODE),prod)
 	  FC=mpif90
-	  FARGS= -O3 -fopenmp -JModules -ftree-vectorize
+	  FARGS= -O3 -fopenmp -JModules -ftree-vectorize -fallow-argument-mismatch
 	  #-ftree-vectorize -ffast-math -ftree-vectorizer-verbose=2 -fopt-info
 	  #FARGS=-g
 	else ifeq ($(MODE),debug)
 	  FC=mpif90
-	  FARGS= -O3 -fopenmp -g -JModules -Wunused-variable -fcheck=bound -ftree-vectorize
+	  FARGS= -O3 -fopenmp -g -JModules -Wunused-variable -fcheck=bound -ftree-vectorize -fallow-argument-mismatch
 	else ifeq ($(MODE),prod_spectral)
 	  FC=mpif90
-	  FARGS= -O3 -fopenmp -JModules -ftree-vectorize
+	  FARGS= -O3 -fopenmp -JModules -ftree-vectorize -fallow-argument-mismatch
 	else ifeq ($(MODE),debug_spectral)
 	  FC=mpif90
-	  FARGS= -O3 -fopenmp -JModules -Wunused-variable -ftree-vectorize
+	  FARGS= -O3 -fopenmp -JModules -Wunused-variable -ftree-vectorize -fallow-argument-mismatch
 	else ifeq ($(MODE),dev)
 	  FC=mpif90
-	  FARGS= -O3 -D DEV=1 -fopenmp -JModules -ftree-vectorize
+	  FARGS= -O3 -D DEV=1 -fopenmp -JModules -ftree-vectorize -fallow-argument-mismatch
 	  #-ftree-vectorize -ffast-math -ftree-vectorizer-verbose=2 -fopt-info
 	  #FARGS=-g
 	else ifeq ($(MODE),devdebug)
 	  FC=mpif90
-	  FARGS= -O3 -D DEV=1 -fopenmp -g -JModules  -Wunused-variable -fcheck=bound -ftree-vectorize
+	  FARGS= -O3 -D DEV=1 -fopenmp -g -JModules  -Wunused-variable -fcheck=bound -ftree-vectorize -fallow-argument-mismatch
 	  #-ftree-vectorize -ffast-math -ftree-vectorizer-verbose=2 -fopt-info
 	  #FARGS=-g
 	else ifeq ($(MODE),novec)
 	  FC=mpif90
-	  FARGS= -D NOVEC=0 -O3 -fopenmp -JModules
+	  FARGS= -D NOVEC=0 -O3 -fopenmp -JModules -fallow-argument-mismatch
         else ifeq ($(MODE),library)
           FC=mpif90
-          FARGS= -O3 -fopenmp -JModules -ftree-vectorize -fPIC
+          FARGS= -O3 -fopenmp -JModules -ftree-vectorize -fPIC -fallow-argument-mismatch
 	endif
 
 	# ___ Architecture ________

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ CC=mpicc
 CPP=mpic++
 
 # Fortran compiler arguments
-FARGS= -g -fbounds-check -O3 -fopenmp -JModules -fallow-argument-mismatch
+FARGS= -g -fbounds-check -O3 -fopenmp -JModules
 # C compiler Arguments
 CARGS= -g -O3 -fopenmp
 # C++ compiler Arguments
@@ -258,34 +258,34 @@ ifeq ($(COMP),gnu)
 
   ifeq ($(MODE),prod)
 	  FC=mpif90
-	  FARGS= -O3 -fopenmp -JModules -ftree-vectorize -fallow-argument-mismatch
+	  FARGS= -O3 -fopenmp -JModules -ftree-vectorize
 	  #-ftree-vectorize -ffast-math -ftree-vectorizer-verbose=2 -fopt-info
 	  #FARGS=-g
 	else ifeq ($(MODE),debug)
 	  FC=mpif90
-	  FARGS= -O3 -fopenmp -g -JModules -Wunused-variable -fcheck=bound -ftree-vectorize -fallow-argument-mismatch
+	  FARGS= -O3 -fopenmp -g -JModules -Wunused-variable -fcheck=bound -ftree-vectorize
 	else ifeq ($(MODE),prod_spectral)
 	  FC=mpif90
-	  FARGS= -O3 -fopenmp -JModules -ftree-vectorize -fallow-argument-mismatch
+	  FARGS= -O3 -fopenmp -JModules -ftree-vectorize
 	else ifeq ($(MODE),debug_spectral)
 	  FC=mpif90
-	  FARGS= -O3 -fopenmp -JModules -Wunused-variable -ftree-vectorize -fallow-argument-mismatch
+	  FARGS= -O3 -fopenmp -JModules -Wunused-variable -ftree-vectorize
 	else ifeq ($(MODE),dev)
 	  FC=mpif90
-	  FARGS= -O3 -D DEV=1 -fopenmp -JModules -ftree-vectorize -fallow-argument-mismatch
+	  FARGS= -O3 -D DEV=1 -fopenmp -JModules -ftree-vectorize
 	  #-ftree-vectorize -ffast-math -ftree-vectorizer-verbose=2 -fopt-info
 	  #FARGS=-g
 	else ifeq ($(MODE),devdebug)
 	  FC=mpif90
-	  FARGS= -O3 -D DEV=1 -fopenmp -g -JModules  -Wunused-variable -fcheck=bound -ftree-vectorize -fallow-argument-mismatch
+	  FARGS= -O3 -D DEV=1 -fopenmp -g -JModules  -Wunused-variable -fcheck=bound -ftree-vectorize
 	  #-ftree-vectorize -ffast-math -ftree-vectorizer-verbose=2 -fopt-info
 	  #FARGS=-g
 	else ifeq ($(MODE),novec)
 	  FC=mpif90
-	  FARGS= -D NOVEC=0 -O3 -fopenmp -JModules -fallow-argument-mismatch
+	  FARGS= -D NOVEC=0 -O3 -fopenmp -JModules
         else ifeq ($(MODE),library)
           FC=mpif90
-          FARGS= -O3 -fopenmp -JModules -ftree-vectorize -fPIC -fallow-argument-mismatch
+          FARGS= -O3 -fopenmp -JModules -ftree-vectorize -fPIC
 	endif
 
 	# ___ Architecture ________

--- a/src/field_solvers/Maxwell/yee_solver/yee.F90
+++ b/src/field_solvers/Maxwell/yee_solver/yee.F90
@@ -525,10 +525,10 @@ subroutine pxrpush_emrz_evec_multimode( &
 
      ! advance Etheta
 #ifndef WARPX
-  !$OMP DO COLLAPSE(2)
+  !$OMP DO
 #endif
 !$acc parallel deviceptr(Et,Bz,Br,Jt)
-!$acc loop gang vector collapse(2)
+!$acc loop gang vector
      do k   = tlo(2), thi(2)
        do j = tlo(1), thi(1)
          if (j /= 0) then
@@ -571,10 +571,10 @@ subroutine pxrpush_emrz_evec_multimode( &
 
      ! advance Ez
 #ifndef WARPX
-  !$OMP DO COLLAPSE(2)
+  !$OMP DO
 #endif
 !$acc parallel deviceptr(Ez,Br,Bt,Jz)
-!$acc loop gang vector collapse(2)
+!$acc loop gang vector
      do k   = zlo(2), zhi(2)
        do j = zlo(1), zhi(1)
          if (j /= 0) then

--- a/src/particle_pushers/particle_pusher_manager_3d.F90
+++ b/src/particle_pushers/particle_pusher_manager_3d.F90
@@ -53,7 +53,7 @@ SUBROUTINE field_gathering_plus_particle_pusher
   USE mpi
   USE params, ONLY: dt, fg_p_pp_separated
   USE particle_properties, ONLY: nspecies, particle_pusher
-  USE picsar_precision, ONLY: idp
+  USE picsar_precision, ONLY: idp, lp
   USE shared_data, ONLY: c_dim, dx, dy, dz, nx, ny, nz
   IMPLICIT NONE
 
@@ -301,7 +301,7 @@ SUBROUTINE field_gathering_plus_particle_pusher_sub(exg, eyg, ezg, bxg, byg, bzg
               curr_tile%nx_cells_tile, curr_tile%ny_cells_tile,                       &
               curr_tile%nz_cells_tile, nxjg, nyjg, nzjg, noxx, noyy, nozz,            &
               extile, eytile, eztile, bxtile, bytile,                                 &
-              bztile, .FALSE., l_lower_order_in_v_in, LVEC_fieldgathe,                &
+              bztile, logical(.FALSE., lp), l_lower_order_in_v_in, LVEC_fieldgathe,                &
               fieldgathe)
 
             CASE DEFAULT! 3D CASE
@@ -315,7 +315,7 @@ SUBROUTINE field_gathering_plus_particle_pusher_sub(exg, eyg, ezg, bxg, byg, bzg
               curr_tile%nx_cells_tile, curr_tile%ny_cells_tile,                       &
               curr_tile%nz_cells_tile, nxjg, nyjg, nzjg, noxx, noyy, nozz,            &
               extile, eytile, eztile, bxtile, bytile,                                 &
-              bztile , .FALSE., l_lower_order_in_v_in, lvec_fieldgathe,               &
+              bztile , logical(.FALSE., lp), l_lower_order_in_v_in, lvec_fieldgathe,               &
               fieldgathe)
             END SELECT
 


### PR DESCRIPTION
I have recently tried to compile PICSAR and I got two different error messages:
```
mpif90 -O3 -fopenmp -JModules -ftree-vectorize  -c -o src/field_solvers/Maxwell/yee_solver/yee.o src/field_solvers/Maxwell/yee_solver/yee.F90
src/field_solvers/Maxwell/yee_solver/yee.F90:541:46:

  541 |        if (tlo(1) <= 0 .and. 0 <= thi(1)) then
      |                                              1
Error: collapsed !$OMP DO loops not perfectly nested at (1)
src/field_solvers/Maxwell/yee_solver/yee.F90:589:46:

  589 |        if (zlo(1) <= 0 .and. 0 <= zhi(1)) then
      |                                              1
Error: collapsed !$OMP DO loops not perfectly nested at (1)
```
```
src/particle_pushers/particle_pusher_manager_3d.F90:304:22:

  304 |               bztile,  .FALSE., l_lower_order_in_v_in, LVEC_fieldgathe,                &
      |                      1
......
 1092 |                 bztile , l4symtry_in, l_lower_order_in_v_in, lvect,                   &
      |                         2
Error: Type mismatch between actual argument at (1) and actual argument at (2) (LOGICAL(4)/LOGICAL(8)).
src/particle_pushers/particle_pusher_manager_3d.F90:318:23:

  318 |               bztile , .FALSE., l_lower_order_in_v_in, lvec_fieldgathe,               &
      |                       1
......
 1104 |                 bztile , l4symtry_in, l_lower_order_in_v_in, lvect,                   &
      |                         2
Error: Type mismatch between actual argument at (1) and actual argument at (2) (LOGICAL(4)/LOGICAL(8)).
```

This PR should fix both issues: I have removed the `collapse(2)` clause from the OMP directives and I have  added the fix proposed by @dpgrote  in https://github.com/ECP-WarpX/picsar/issues/24 