### PR TITLE
Fix bug related to corner case in photon emission

### DIFF
--- a/multi_physics/QED/QED_tests/test_picsar_cmath_overload.cpp
+++ b/multi_physics/QED/QED_tests/test_picsar_cmath_overload.cpp
@@ -32,6 +32,8 @@ void test_case_cmath_overloads()
         BOOST_CHECK_EQUAL(m_log(val), std::log(val));
         BOOST_CHECK_EQUAL(m_tanh(val), std::tanh(val));
         BOOST_CHECK_EQUAL(m_tanh(-val), std::tanh(-val));
+        BOOST_CHECK_EQUAL(m_round(val), std::round(val));
+        BOOST_CHECK_EQUAL(m_round(-val), std::round(-val));
      }
 
     const auto vals_floor_fabs = std::vector<RealType>{0.0, 0.001, 0.3, 0.7,

--- a/multi_physics/QED/QED_tests/test_picsar_math_constants.cpp
+++ b/multi_physics/QED/QED_tests/test_picsar_math_constants.cpp
@@ -32,6 +32,7 @@ void test_case_const_math()
     const auto exp_one_third = static_cast<RealType>(1.0/3.0);
     const auto exp_two_thirds = static_cast<RealType>(2.0/3.0);
     const auto exp_five_thirds = static_cast<RealType>(5.0/3.0);
+    const auto exp_epsilon = std::numeric_limits<RealType>::epsilon();
 
     BOOST_CHECK_EQUAL(pi<RealType>, exp_pi);
     BOOST_CHECK_EQUAL(zero<RealType>, exp_zero);
@@ -43,6 +44,7 @@ void test_case_const_math()
     BOOST_CHECK_EQUAL(one_third<RealType>, exp_one_third);
     BOOST_CHECK_EQUAL(two_thirds<RealType>, exp_two_thirds);
     BOOST_CHECK_EQUAL(five_thirds<RealType>, exp_five_thirds);
+    BOOST_CHECK_EQUAL(epsilon<RealType>, exp_epsilon);
 }
 
 BOOST_AUTO_TEST_CASE( picsar_const_math )

--- a/multi_physics/QED/QED_tests/test_picsar_quantum_sync_tables.cpp
+++ b/multi_physics/QED/QED_tests/test_picsar_quantum_sync_tables.cpp
@@ -47,7 +47,9 @@ const double chi_min = 0.001;
 const double chi_max = 1000;
 const int how_many = 500;
 const int how_many_frac = 500;
+const int frac_first = 300;
 const double frac_min = 1e-12;
+const double frac_switch = 5e-2;
 
 template <typename RealType, typename VectorType>
 auto get_table()
@@ -73,6 +75,19 @@ auto get_em_table()
     return photon_emission_lookup_table<RealType, VectorType>{params};
 }
 
+template <typename RealType, typename VectorType>
+auto get_tailopt_em_table()
+{
+    const auto params =
+        tailopt_photon_emission_lookup_table_params<RealType>{
+            static_cast<RealType>(chi_min),
+            static_cast<RealType>(chi_max),
+            static_cast<RealType>(frac_min),
+            static_cast<RealType>(frac_switch),
+            how_many, how_many_frac, frac_first};
+
+    return tailopt_photon_emission_lookup_table<RealType, VectorType>{params};
+}
 
 
 // ------------- Tests --------------
@@ -308,4 +323,127 @@ BOOST_AUTO_TEST_CASE( picsar_quantum_sync_photon_emission_table_serialization)
 {
     check_photon_emission_table_serialization<double, std::vector<double>>();
     check_photon_emission_table_serialization<float, std::vector<float>>();
+}
+
+template <typename RealType, typename VectorType>
+void check_tailopt_photon_emission_table()
+{
+    auto table = get_tailopt_em_table<RealType, VectorType>();
+    BOOST_CHECK_EQUAL(table.is_init(),false);
+
+    auto coords = table.get_all_coordinates();
+
+    BOOST_CHECK_EQUAL(coords.size(),how_many*how_many_frac);
+/*
+    const RealType log_chi_min = log(chi_min);
+    const RealType log_chi_max = log(chi_max);
+    const RealType log_frac_min = log(frac_min);
+
+    for (int i = 0 ; i < how_many*how_many_frac; ++i){
+         auto res_1 = coords[i][0];
+         auto res_2 = coords[i][1];
+         const auto ii = i/how_many_frac;
+         const auto jj = i%how_many_frac;
+         auto expected_1 = static_cast<RealType>(
+             exp(log_chi_min +ii*(log_chi_max-log_chi_min)/(how_many-1)));
+        auto expected_2 = static_cast<RealType>(
+             expected_1*exp(log_frac_min +jj*(0.0-log_frac_min)/(how_many_frac-1)));
+
+         BOOST_CHECK_SMALL((res_1-expected_1)/expected_1, tolerance<RealType>());
+         if(expected_2 != static_cast<RealType>(0.0))
+            BOOST_CHECK_SMALL((res_2-expected_2)/expected_2, tolerance<RealType>());
+        else
+            BOOST_CHECK_SMALL((res_2-expected_2), tolerance<RealType>());
+    }
+
+    auto vals = VectorType(coords.size());
+
+    auto functor = [=](std::array<RealType,2> x){
+        return static_cast<RealType>(1.0*pow(x[1]/x[0], 4.0 + log10(x[0])));};
+
+    auto inverse_functor = [=](std::array<RealType,2> x){
+            return static_cast<RealType>(1.0*pow((1-x[1]), 1.0/(4.0 + log10(x[0]))));};
+
+    std::transform(coords.begin(), coords.end(), vals.begin(),functor);
+
+    bool result = table.set_all_vals(vals);
+    BOOST_CHECK_EQUAL(result,true);
+    BOOST_CHECK_EQUAL(table.is_init(),true);
+
+
+    auto table_2 = get_em_table<RealType, VectorType>();
+    BOOST_CHECK_EQUAL(table_2 == table, false);
+    BOOST_CHECK_EQUAL(table == table, true);
+    BOOST_CHECK_EQUAL(table_2 == table_2, true);
+
+
+    const RealType xo0 = chi_min*0.1;
+    const RealType xo1 = chi_max*10;
+    const RealType x0 = chi_min;
+    const RealType x1 = (chi_max+chi_min)*0.5642 + chi_min;
+    const RealType x2 = chi_max;
+
+    const auto xxs = std::array<RealType, 5>
+        {xo0, x0, x1, x2, xo1};
+    const auto rrs = std::array<RealType, 11>
+            {0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.99};
+
+    for (const auto xx : xxs){
+        for (const auto rr : rrs){
+            auto res = table.interp(xx, rr);
+            auto rxx = xx;
+            if(rxx < chi_min) rxx = chi_min;
+            if(rxx > chi_max) rxx = chi_max;
+            auto expected = inverse_functor(std::array<RealType,2>{rxx, rr})*xx;
+            if(expected < small<RealType>())
+                BOOST_CHECK_SMALL((res-expected)/expected, tolerance<RealType>());
+            else
+                BOOST_CHECK_SMALL((res-expected), tolerance<RealType>());
+
+        }
+    }
+
+    const auto table_view = table.get_view();
+
+    for(auto xx : xxs){
+        for (auto r : rrs)
+            BOOST_CHECK_EQUAL(table_view.interp(xx,r ), table.interp(xx, r));
+    }
+    */
+}
+
+// ***Test Quantum Synchrotron photon emission table
+BOOST_AUTO_TEST_CASE( picsar_quantum_sync_tailopt_photon_emission_table)
+{
+    check_tailopt_photon_emission_table<double, std::vector<double>>();
+    check_tailopt_photon_emission_table<float, std::vector<float>>();
+}
+
+
+template <typename RealType, typename VectorType>
+void check_tailopt_photon_emission_table_serialization()
+{
+    const auto params =
+        tailopt_photon_emission_lookup_table_params<RealType>{
+            static_cast<RealType>(0.1),static_cast<RealType>(10.0),
+            static_cast<RealType>(1e-5), static_cast<RealType>(1e-1),
+            3, 3, 2};
+
+    auto table = tailopt_photon_emission_lookup_table<
+        RealType, VectorType>{params, {1.,2.,3.,4.,5.,6.,7.,8.,9.}};
+
+    auto raw_data = table.serialize();
+    auto new_table =
+        tailopt_photon_emission_lookup_table<RealType, VectorType>{raw_data};
+
+    BOOST_CHECK_EQUAL(new_table.is_init(), true);
+    BOOST_CHECK_EQUAL(new_table == table, true);
+}
+
+
+// ***Test Quantum Synchrotron photon emission table serialization
+BOOST_AUTO_TEST_CASE( picsar_quantum_sync_tailopt_photon_emission_table_serialization)
+{
+    check_tailopt_photon_emission_table_serialization<double, std::vector<double>>();
+    check_tailopt_photon_emission_table_serialization<float, std::vector<float>>();
 }

--- a/multi_physics/QED/QED_tests/test_picsar_quantum_sync_tables.cpp
+++ b/multi_physics/QED/QED_tests/test_picsar_quantum_sync_tables.cpp
@@ -334,23 +334,31 @@ void check_tailopt_photon_emission_table()
     auto coords = table.get_all_coordinates();
 
     BOOST_CHECK_EQUAL(coords.size(),how_many*how_many_frac);
-/*
-    const RealType log_chi_min = log(chi_min);
-    const RealType log_chi_max = log(chi_max);
-    const RealType log_frac_min = log(frac_min);
+
+    const auto log_functor = LogFunctor<RealType>{
+        how_many,
+        static_cast<RealType>(chi_min),
+        static_cast<RealType>(chi_max)};
+
+    const auto tailopt_functor = TailOptFunctor<RealType>{
+        how_many_frac,
+        frac_first,
+        static_cast<RealType>(frac_min),
+        static_cast<RealType>(1.0),
+        static_cast<RealType>(frac_switch)};
 
     for (int i = 0 ; i < how_many*how_many_frac; ++i){
-         auto res_1 = coords[i][0];
-         auto res_2 = coords[i][1];
-         const auto ii = i/how_many_frac;
-         const auto jj = i%how_many_frac;
-         auto expected_1 = static_cast<RealType>(
-             exp(log_chi_min +ii*(log_chi_max-log_chi_min)/(how_many-1)));
-        auto expected_2 = static_cast<RealType>(
-             expected_1*exp(log_frac_min +jj*(0.0-log_frac_min)/(how_many_frac-1)));
 
-         BOOST_CHECK_SMALL((res_1-expected_1)/expected_1, tolerance<RealType>());
-         if(expected_2 != static_cast<RealType>(0.0))
+        auto res_1 = coords[i][0];
+        auto res_2 = coords[i][1];
+        const auto ii = i/how_many_frac;
+        const auto jj = i%how_many_frac;
+
+        auto expected_1 = std::exp(log_functor(ii));
+        auto expected_2 = std::exp(tailopt_functor(jj))*expected_1;
+
+        BOOST_CHECK_SMALL((res_1-expected_1)/expected_1, tolerance<RealType>());
+        if(expected_2 != static_cast<RealType>(0.0))
             BOOST_CHECK_SMALL((res_2-expected_2)/expected_2, tolerance<RealType>());
         else
             BOOST_CHECK_SMALL((res_2-expected_2), tolerance<RealType>());
@@ -370,12 +378,10 @@ void check_tailopt_photon_emission_table()
     BOOST_CHECK_EQUAL(result,true);
     BOOST_CHECK_EQUAL(table.is_init(),true);
 
-
-    auto table_2 = get_em_table<RealType, VectorType>();
+    auto table_2 = get_tailopt_em_table<RealType, VectorType>();
     BOOST_CHECK_EQUAL(table_2 == table, false);
     BOOST_CHECK_EQUAL(table == table, true);
     BOOST_CHECK_EQUAL(table_2 == table_2, true);
-
 
     const RealType xo0 = chi_min*0.1;
     const RealType xo1 = chi_max*10;
@@ -386,7 +392,7 @@ void check_tailopt_photon_emission_table()
     const auto xxs = std::array<RealType, 5>
         {xo0, x0, x1, x2, xo1};
     const auto rrs = std::array<RealType, 11>
-            {0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.99};
+            {0.0, 1.0e-4, 1.0e-3, 1.0e-2, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.99};
 
     for (const auto xx : xxs){
         for (const auto rr : rrs){
@@ -409,7 +415,7 @@ void check_tailopt_photon_emission_table()
         for (auto r : rrs)
             BOOST_CHECK_EQUAL(table_view.interp(xx,r ), table.interp(xx, r));
     }
-    */
+
 }
 
 // ***Test Quantum Synchrotron photon emission table

--- a/multi_physics/QED/QED_tests/test_picsar_tables.cpp
+++ b/multi_physics/QED/QED_tests/test_picsar_tables.cpp
@@ -55,12 +55,12 @@ const double ymax = 8.0;
 const int xsize = 100;
 const int ysize = 100;
 
-const int gxsize = 100;
-const int gysize = 100;
+const int gxsize = 105;
+const int gysize = 105;
 const double gxmin = 1e-12;
-const double gxmax = 10.0;
+const double gxmax = 11.0;
 const double gymin = 1e-10;
-const double gymax = 8.0;
+const double gymax = 9.0;
 const double gxswitch = 8.0;
 const double gyswitch = 6.0;
 const int gxfirst = 80;
@@ -72,48 +72,48 @@ const double glogyswitch = std::log(gyswitch);
 
 const auto x_functor = [](int i)
     {
-        if (i < xfirst){
-            return std::exp(logxmin + i*(logxswitch-logxmin)/(xfirst-1));
+        if (i < gxfirst){
+            return std::exp(glogxmin + i*(glogxswitch-glogxmin)/(gxfirst-1));
         }
         else{
-            return xswitch+((i+1)-xfirst)*(xmax-xswitch)/(xsize-xfirst);
+            return gxswitch+((i+1)-gxfirst)*(gxmax-gxswitch)/(xsize-gxfirst);
         }
     };
 
 const auto y_functor = [](int j)
     {
-        if (j < yfirst){
-            return std::exp(logymin + j*(logyswitch-logymin)/(yfirst -1));
+        if (j < gyfirst){
+            return std::exp(glogymin + j*(glogyswitch-glogymin)/(gyfirst -1));
         }
         else{
-            return yswitch+((j+1)-yfirst)*(ymax-yswitch)/(ysize-yfirst);
+            return gyswitch+((j+1)-gyfirst)*(gymax-gyswitch)/(ysize-gyfirst);
         }
     };
 
 
 const auto ix_functor = [](double x)
     {
-        if (x < xswitch){
+        if (x < gxswitch){
             const auto logx = std::log(x);
             return static_cast<int>(
-                std::round( (xfirst -1)*(logx-logxmin)/(logxswitch - logxmin)));
+                std::round( (gxfirst -1)*(logx-glogxmin)/(glogxswitch - glogxmin)));
         }
         else{
             return static_cast<int>(
-                std::floor(xfirst + (xsize-xfirst - 1)*(x-xswitch)/(xmax - xswitch)));
+                std::floor(gxfirst + (gxsize-gxfirst - 1)*(x-gxswitch)/(gxmax - gxswitch)));
         }
     };
 
 const auto iy_functor = [](double y)
     {
-        if (y < yswitch){
+        if (y < gyswitch){
             const auto logy = std::log(y);
             return static_cast<int>(
-                std::round( (yfirst -1)*(logy-logymin)/(logyswitch - logymin)));
+                std::round( (gyfirst -1)*(logy-glogymin)/(glogyswitch - glogymin)));
         }
         else{
             return static_cast<int>(
-                std::floor(yfirst + (ysize-yfirst - 1)*(y-yswitch)/(ymax - yswitch)));
+                std::floor(gyfirst + (gysize-gyfirst - 1)*(y-gyswitch)/(gymax - gyswitch)));
         }
     };
 
@@ -152,8 +152,8 @@ using Generic2DTableType = generic_2d_table<
 auto make_generic_2d_table()
 {
     auto tab = Generic2DTableType(
-            xsize, ysize,
-            std::vector<double>(xsize*ysize),
+            gxsize, gysize,
+            std::vector<double>(gxsize*gysize),
             x_functor, y_functor, ix_functor, iy_functor);
 
     const auto coords = tab.get_all_coordinates();
@@ -357,23 +357,23 @@ void check_generic_table_2d(
     const Generic2DTableType& tab)
 {
     const auto rxmin = tab.get_x_min();
-    BOOST_CHECK_EQUAL(rxmin, xmin);
+    BOOST_CHECK_EQUAL(rxmin, gxmin);
     const auto rxmax = tab.get_x_max();
-    BOOST_CHECK_EQUAL(rxmax, xmax);
+    BOOST_CHECK_EQUAL(rxmax, gxmax);
     const auto rhowmany_x =  tab.get_how_many_x();
-    BOOST_CHECK_EQUAL(rhowmany_x, xsize);
+    BOOST_CHECK_EQUAL(rhowmany_x, gxsize);
     const auto rxsize =  tab.get_x_size();
-    BOOST_CHECK_EQUAL(rxsize, xmax-xmin);
+    BOOST_CHECK_EQUAL(rxsize, gxmax-gxmin);
     //const auto rdx =  tab.get_dx();
     //BOOST_CHECK_EQUAL(rdx, (xmax-xmin)/(rhowmany_x-1));
     const auto rymin = tab.get_y_min();
-    BOOST_CHECK_EQUAL(rymin, ymin);
+    BOOST_CHECK_EQUAL(rymin, gymin);
     const auto rymax = tab.get_y_max();
-    BOOST_CHECK_EQUAL(rymax, ymax);
+    BOOST_CHECK_EQUAL(rymax, gymax);
     const auto rhowmany_y =  tab.get_how_many_y();
-    BOOST_CHECK_EQUAL(rhowmany_y, ysize);
+    BOOST_CHECK_EQUAL(rhowmany_y, gysize);
     const auto rysize =  tab.get_y_size();
-    BOOST_CHECK_EQUAL(rysize, ymax-ymin);
+    BOOST_CHECK_EQUAL(rysize, gymax-gymin);
     //const auto rdy =  tab.get_dy();
     //BOOST_CHECK_EQUAL(rdy, (ymax-ymin)/(rhowmany_y-1));
 }
@@ -508,6 +508,6 @@ BOOST_AUTO_TEST_CASE( picsar_generic_2d_table_constructor_getters)
     auto copy_gtab_2d = gtab_2d;
 
     check_generic_table_2d(gtab_2d);
-    //check_generic_table_2d(const_gtab_2d);
-    //check_generic_table_2d(copy_gtab_2d);
+    check_generic_table_2d(const_gtab_2d);
+    check_generic_table_2d(copy_gtab_2d);
 }

--- a/multi_physics/QED/QED_tests/test_picsar_tables.cpp
+++ b/multi_physics/QED/QED_tests/test_picsar_tables.cpp
@@ -496,6 +496,58 @@ void check_generic_table_2d(
     BOOST_CHECK_EQUAL(rysize, gymax-gymin);
 }
 
+void check_generic_table_2d_interp_one_coord(
+        const Generic2DTableType& tab)
+{
+    const auto x0 = tab.get_x_coord(0);
+    const auto x1 = tab.get_x_coord(xsize/4);
+    const auto x2 = tab.get_x_coord(xsize-1);
+    const auto x3 = 0.732*(x1-x0) + x0;
+    const auto x4 = 0.118*(x2-x1) + x1;
+    const auto xarr = std::array<double, 5>{x0,x1,x2,x3,x4};
+    const auto jarr = std::array<int, 5>{0,1,5,27,ysize-1};
+
+    for (auto xx : xarr){
+        for (auto jj : jarr)
+        {
+            const auto yy = tab.get_y_coord(jj);
+            const auto res = tab.interp_first_coord(xx, jj);
+            const auto exp = linear_function(xx, yy);
+            BOOST_CHECK_SMALL((res - exp)/exp, tolerance<double>());
+        }
+    }
+
+
+    const auto y0 = tab.get_y_coord(0);
+    const auto y1 = tab.get_y_coord(ysize/4);
+    const auto y2 = tab.get_y_coord(ysize-1);
+    const auto y3 = 0.8569*(y1-y0) + y0;
+    const auto y4 = 0.3467*(y2-y1) + y1;
+    const auto yarr = std::array<double, 5>{y0,y1,y2,y3,y4};
+    const auto iarr = std::array<int, 5>{0,1,5,27,xsize-1};
+
+    for (auto yy : yarr){
+        for (auto ii : iarr)
+        {
+            const auto xx = tab.get_x_coord(ii);
+            const auto res = tab.interp_second_coord(ii, yy);
+            const auto exp = linear_function(xx, yy);
+            BOOST_CHECK_SMALL((res - exp)/exp, tolerance<double>());
+        }
+    }
+}
+
+void check_generic_table_2d_interp(int i, int j, double val)
+{
+    auto gtab_2d = make_generic_2d_table();
+    gtab_2d.set_val(i,j,val);
+    const auto xx = gtab_2d.get_x_coord(i);
+    const auto yy = gtab_2d.get_y_coord(j);
+    const auto res =gtab_2d.interp(xx,yy);
+
+    BOOST_CHECK_SMALL((res - val)/val, tolerance<double>());
+}
+
 // ***Test equispaced_1d_table constructor and getters
 BOOST_AUTO_TEST_CASE( picsar_equispaced_1d_table_constructor_getters)
 {
@@ -633,24 +685,22 @@ BOOST_AUTO_TEST_CASE( picsar_generic_2d_table_constructor_getters)
 // ***Test generic_2d_table single coordinate interpolation
 BOOST_AUTO_TEST_CASE( picsar_generic_2d_table_interp_one_coord)
 {
-    const auto gtab_2d = make_generic_2d_table();
+    const auto const_gtab_2d = make_generic_2d_table();
 
-    //check_table_2d_interp_one_coord(const_tab_2d);
+    check_generic_table_2d_interp_one_coord(const_gtab_2d);
 }
 
 // ***Test generic_2d_table interp
 BOOST_AUTO_TEST_CASE( picsar_generic_2d_table_constructor_interp)
 {
-    auto gtab_2d = make_generic_2d_table();
-    const auto val = 1000.0;
-    const int i = 10;
-    const int j = 20;
-    gtab_2d.set_val(i,j,val);
-    const auto xx = gtab_2d.get_x_coord(i);
-    const auto yy = gtab_2d.get_y_coord(j);
-    const auto res =gtab_2d.interp(xx,yy);
-
-    BOOST_CHECK_SMALL((res - val)/val, tolerance<double>());
+    check_generic_table_2d_interp(0, 0, 1000.0);
+    check_generic_table_2d_interp(gxsize-1, gysize-1, -1000.0);
+    check_generic_table_2d_interp(gxsize-1, 0, 1000.0);
+    check_generic_table_2d_interp(0, gysize-1, -1000.0);
+    check_generic_table_2d_interp(5, 5, 1000.0);
+    check_generic_table_2d_interp(gxsize-5, gysize-5, -1000.0);
+    check_generic_table_2d_interp(gxsize-5, 5, 1000.0);
+    check_generic_table_2d_interp(5, gysize-5, -1000.0);
 }
 
 // ***Test generic_2d_table equality

--- a/multi_physics/QED/QED_tests/test_picsar_tables.cpp
+++ b/multi_physics/QED/QED_tests/test_picsar_tables.cpp
@@ -55,6 +55,62 @@ const double ymax = 8.0;
 const int xsize = 100;
 const int ysize = 100;
 
+const double xswitch = 8.0;
+const double yswitch = 6.0;
+const int xfirst = 80;
+const int yfirst = 80;
+const double logxmin = std::log(xmin);
+const double logxswitch = std::log(xswitch);
+const double logymin = std::log(ymin);
+const double logyswitch = std::log(yswitch);
+
+const auto x_functor = [](int i)
+    {
+        if (i < xfirst){
+            return std::exp(logxmin + i*(logxswitch-logxmin)/(xfirst-1));
+        }
+        else{
+            return xswitch+((i+1)-xfirst)*(xmax-xswitch)/(xsize-xfirst);
+        }
+    };
+
+const auto y_functor = [](int j)
+    {
+        if (j < yfirst){
+            return std::exp(logymin + j*(logyswitch-logymin)/(yfirst -1));
+        }
+        else{
+            return yswitch+((j+1)-yfirst)*(ymax-yswitch)/(ysize-yfirst);
+        }
+    };
+
+
+const auto ix_functor = [](double x)
+    {
+        if (x < xswitch){
+            const auto logx = std::log(x);
+            return static_cast<int>(
+                std::round( (xfirst -1)*(logx-logxmin)/(logxswitch - logxmin)));
+        }
+        else{
+            return static_cast<int>(
+                std::floor(xfirst + (xsize-xfirst - 1)*(x-xswitch)/(xmax - xswitch)));
+        }
+    };
+
+const auto iy_functor = [](double y)
+    {
+        if (y < yswitch){
+            const auto logy = std::log(y);
+            return static_cast<int>(
+                std::round( (yfirst -1)*(logy-logymin)/(logyswitch - logymin)));
+        }
+        else{
+            return static_cast<int>(
+                std::floor(yfirst + (ysize-yfirst - 1)*(y-yswitch)/(ymax - yswitch)));
+        }
+    };
+
 equispaced_1d_table<double, std::vector<double> > make_1d_table()
 {
     std::vector<double> data(xsize);
@@ -80,6 +136,19 @@ equispaced_2d_table<double, std::vector<double> > make_2d_table()
 
     return equispaced_2d_table<double, std::vector<double>>(
         xmin, xmax, ymin, ymax, xsize, ysize, data);
+}
+
+auto make_generic_2d_table()
+{
+    auto tab = generic_2d_table<
+        double, std::vector<double>,
+        typeof(x_functor),typeof(y_functor),
+        typeof(ix_functor),typeof(iy_functor)>(
+            xsize, ysize,
+            std::vector<double>(xsize*ysize),
+            x_functor, y_functor, ix_functor, iy_functor);
+
+    return tab;
 }
 
 

--- a/multi_physics/QED/include/picsar_qed/containers/picsar_tables.hpp
+++ b/multi_physics/QED/include/picsar_qed/containers/picsar_tables.hpp
@@ -802,8 +802,7 @@ namespace containers{
     template <
         typename RealType, typename VectorType,
         typename XMapFunctor, typename YMapFunctor,
-        typename IXMapFunctor, typename IYMapFunctor,
-        typename MapFunctorData>
+        typename IXMapFunctor, typename IYMapFunctor>
     class generic_2d_table
     {
     public:
@@ -819,14 +818,14 @@ namespace containers{
         generic_2d_table(
             int how_many_x, int how_many_y,
             VectorType values,
-            XMapFunctor&& x_map_functor,
-            YMapFunctor&& y_map_functor,
-            IXMapFunctor&& ix_map_functor,
-            IYMapFunctor&& iy_map_functor):
+            XMapFunctor x_map_functor,
+            YMapFunctor y_map_functor,
+            IXMapFunctor ix_map_functor,
+            IYMapFunctor iy_map_functor):
             m_how_many_x{how_many_x}, m_how_many_y{how_many_y},
             m_values{values},
             m_x_map_functor{x_map_functor}, m_y_map_functor{y_map_functor},
-            m_ix_map_functor{iy_map_functor}, m_iy_map_functor{y_map_functor}
+            m_ix_map_functor{ix_map_functor}, m_iy_map_functor{iy_map_functor}
             {}
 
         /**
@@ -890,8 +889,9 @@ namespace containers{
         PXRMP_GPU_QUALIFIER PXRMP_FORCE_INLINE
         bool operator== (
             const generic_2d_table<
-                RealType, VectorType, XMapFunctor, YMapFunctor, IXMapFunctor, IYMapFunctor, MapFunctorData
-            > &rhs) const
+                RealType, VectorType,
+                XMapFunctor, YMapFunctor,
+                IXMapFunctor, IYMapFunctor> &rhs) const
         {
             return
                 (m_how_many_x == rhs.m_how_many_x) &&
@@ -1233,8 +1233,8 @@ namespace containers{
             VectorType m_values; /* values f(x,y) */
             XMapFunctor m_x_map_functor;
             YMapFunctor m_y_map_functor;
-            XMapFunctor m_ix_map_functor;
-            YMapFunctor m_iy_map_functor;
+            IXMapFunctor m_ix_map_functor;
+            IYMapFunctor m_iy_map_functor;
 
         /**
         * Function values are stored internally in a 1D vector.

--- a/multi_physics/QED/include/picsar_qed/containers/picsar_tables.hpp
+++ b/multi_physics/QED/include/picsar_qed/containers/picsar_tables.hpp
@@ -788,7 +788,7 @@ namespace containers{
 
     /**
     * This class implements a generic 2D lookup table for a function f(x, y)
-    * The MapFunctorData struct must implement .deserialize() method, ::serialize(MapFunctorData) methods, and == operator). 
+    * The MapFunctorData struct must implement .deserialize() method, ::serialize(MapFunctorData) methods, and == operator).
     * It must also be trivially copiable.
     *
     * @tparam RealType the floating point type to be used (e.g. double or float)

--- a/multi_physics/QED/include/picsar_qed/math/cmath_overloads.hpp
+++ b/multi_physics/QED/include/picsar_qed/math/cmath_overloads.hpp
@@ -241,6 +241,36 @@ namespace math{
         return fabsf(x);
     }
 
+    /**
+    * This function replaces the overload of round provided
+    * by the Standard Template Library. It calls either
+    * round or roundf in cmath depending on the variable type.
+    *
+    * @tparam RealType the floating point type to be used
+    * @param[in] x argument
+    * @return round(x)
+    */
+    template<typename RealType>
+    PXRMP_GPU_QUALIFIER PXRMP_FORCE_INLINE
+    RealType m_round(const RealType x) noexcept
+    {
+        return round(x);
+    }
+
+    template<>
+    PXRMP_GPU_QUALIFIER PXRMP_FORCE_INLINE
+    double m_round(const double x) noexcept
+    {
+        return round(x);
+    }
+
+    template<>
+    PXRMP_GPU_QUALIFIER PXRMP_FORCE_INLINE
+    float m_round(const float x) noexcept
+    {
+        return roundf(x);
+    }
+
 #else
 
     /**
@@ -353,6 +383,21 @@ namespace math{
     }
 
 #endif
+
+    /**
+    * This function replaces the overload of round provided
+    * by the Standard Template Library.
+    *
+    * @tparam RealType the floating point type to be used
+    * @param[in] x argument
+    * @return round(x)
+    */
+    template<typename RealType>
+    PXRMP_GPU_QUALIFIER PXRMP_FORCE_INLINE
+    RealType m_round(const RealType x) noexcept
+    {
+        return std::round(x);
+    }
 
 }
 }

--- a/multi_physics/QED/include/picsar_qed/math/math_constants.h
+++ b/multi_physics/QED/include/picsar_qed/math/math_constants.h
@@ -4,6 +4,8 @@
 //Should be included by all the src files of the library
 #include "picsar_qed/qed_commons.h"
 
+#include <limits>
+
 namespace picsar{
 namespace multi_physics{
 namespace math{
@@ -40,6 +42,9 @@ namespace math{
 
     template<typename RealType = double>
     constexpr RealType five_thirds = RealType(5.0/3.0);
+
+    template<typename RealType = double>
+    constexpr RealType epsilon = std::numeric_limits<RealType>::epsilon();
     //________________________
 }
 }

--- a/multi_physics/QED/include/picsar_qed/physics/quantum_sync/quantum_sync_engine_tables.hpp
+++ b/multi_physics/QED/include/picsar_qed/physics/quantum_sync/quantum_sync_engine_tables.hpp
@@ -869,7 +869,7 @@ class ILogFunctor
         using namespace picsar::multi_physics::math;
 
         return static_cast<int>(
-            math::m_floor(m_logzmin + (m_zsize - 1)*(logz-m_logzmin)/(m_logzmax - m_logzmin)));
+            math::m_floor((m_zsize - 1)*(logz-m_logzmin)/(m_logzmax - m_logzmin)));
     }
 
     bool operator== (const ILogFunctor<RealType>& rhs) const

--- a/multi_physics/QED/include/picsar_qed/physics/quantum_sync/quantum_sync_engine_tables.hpp
+++ b/multi_physics/QED/include/picsar_qed/physics/quantum_sync/quantum_sync_engine_tables.hpp
@@ -1375,7 +1375,9 @@ class ITailOptFunctor
                 }
 
                 const auto log_e_chi_part = m_log(e_chi_part);
-                const auto log_prob = m_log(one<RealType>-unf_zero_one_minus_epsi);
+
+                const auto tlog_prob = m_log(one<RealType>-unf_zero_one_minus_epsi);
+                const auto log_prob = (tlog_prob >= zero<RealType>) ? -epsilon<RealType> : tlog_prob;
 
                 const auto upper_frac_index = utils::picsar_upper_bound_functor(
                     0, m_params.frac_how_many,log_prob,[&](int i){


### PR DESCRIPTION
In extremely rare cases, in the function which calculates the properties of quantum synchrotron photons, the quantity `log_prob` could be exactly zero. In these cases,  photons are emitted at the highest possible energy, since their quantum parameter becomes identical to the quantum parameter of the emitting particle. The right behavior should be to find the lowest photon quantum parameter corresponding to  a cumulative probability distribution equal to one. This PR fixes this corner case.