### PR TITLE
Fix corner case in photon emission

### DIFF
--- a/multi_physics/QED/QED_tests/test_picsar_math_constants.cpp
+++ b/multi_physics/QED/QED_tests/test_picsar_math_constants.cpp
@@ -10,6 +10,7 @@
 #include <picsar_qed/math/math_constants.h>
 
 #include <cmath>
+#include <limits>
 
 using namespace picsar::multi_physics::math;
 
@@ -32,6 +33,7 @@ void test_case_const_math()
     const auto exp_one_third = static_cast<RealType>(1.0/3.0);
     const auto exp_two_thirds = static_cast<RealType>(2.0/3.0);
     const auto exp_five_thirds = static_cast<RealType>(5.0/3.0);
+    const auto exp_epsilon = std::numeric_limits<RealType>::epsilon();
 
     BOOST_CHECK_EQUAL(pi<RealType>, exp_pi);
     BOOST_CHECK_EQUAL(zero<RealType>, exp_zero);
@@ -43,6 +45,7 @@ void test_case_const_math()
     BOOST_CHECK_EQUAL(one_third<RealType>, exp_one_third);
     BOOST_CHECK_EQUAL(two_thirds<RealType>, exp_two_thirds);
     BOOST_CHECK_EQUAL(five_thirds<RealType>, exp_five_thirds);
+    BOOST_CHECK_EQUAL(epsilon<RealType>, exp_epsilon);
 }
 
 BOOST_AUTO_TEST_CASE( picsar_const_math )

--- a/multi_physics/QED/include/picsar_qed/math/math_constants.h
+++ b/multi_physics/QED/include/picsar_qed/math/math_constants.h
@@ -4,6 +4,8 @@
 //Should be included by all the src files of the library
 #include "picsar_qed/qed_commons.h"
 
+#include <limits>
+
 namespace picsar{
 namespace multi_physics{
 namespace math{
@@ -40,6 +42,9 @@ namespace math{
 
     template<typename RealType = double>
     constexpr RealType five_thirds = RealType(5.0/3.0);
+
+    template<typename RealType = double>
+    constexpr RealType epsilon = std::numeric_limits<RealType>::epsilon();
     //________________________
 }
 }

--- a/multi_physics/QED/include/picsar_qed/physics/quantum_sync/quantum_sync_engine_tables.hpp
+++ b/multi_physics/QED/include/picsar_qed/physics/quantum_sync/quantum_sync_engine_tables.hpp
@@ -651,7 +651,10 @@ namespace quantum_sync{
                 }
 
                 const auto log_e_chi_part = m_log(e_chi_part);
-                const auto log_prob = m_log(one<RealType>-unf_zero_one_minus_epsi);
+
+                const auto tlog_prob = m_log(one<RealType>-unf_zero_one_minus_epsi);
+                const auto log_prob = (tlog_prob >= zero<RealType>) ?
+                    - epsilon<RealType> : tlog_prob; // Avoid numerical issues.
 
                 const auto upper_frac_index = utils::picsar_upper_bound_functor(
                     0, m_params.frac_how_many,log_prob,[&](int i){


### PR DESCRIPTION
In extremely rare cases, in the function which calculates the properties of quantum synchrotron photons, the quantity log_prob could be exactly zero. In these cases, photons are emitted at the highest possible energy, since their quantum parameter becomes identical to the quantum parameter of the emitting particle. The right behavior should be to find the lowest photon quantum parameter corresponding to a cumulative probability distribution equal to one. This PR should fix this corner case.