### PR TITLE
Replace erroneous text on current deposition

### DIFF
--- a/Doxygen/pages/latex_theory/Gather/Field_gather.tex
+++ b/Doxygen/pages/latex_theory/Gather/Field_gather.tex
@@ -1,67 +1,32 @@
 \input{../newcommands}
 
-The current densities are deposited on the computational grid from
-the particle position and velocities, employing splines of various
-orders \cite{Abejcp86}.
-
-\begin{subequations}
-\begin{eqnarray}
-\rho & = & \frac{1}{\Delta x \Delta y \Delta z}\sum_nq_nS_n\\
-\mathbf{J} & = & \frac{1}{\Delta x \Delta y \Delta z}\sum_nq_n\mathbf{v_n}S_n
-\end{eqnarray}
-\end{subequations}
-
-In most applications, it is essential to prevent the accumulation
-of errors resulting from the violation of the discretized Gauss' Law.
-This is accomplished by providing a method for depositing the current
-from the particles to the grid that preserves the discretized Gauss'
-Law, or by providing a mechanism for ``divergence cleaning'' \cite{Birdsalllangdon,Langdoncpc92,Marderjcp87,Vaypop98,Munzjcp2000}.
-For the former, schemes that allow a deposition of the current that
-is exact when combined with the Yee solver is given in \cite{Villasenorcpc92}
-for linear splines and in \cite{Esirkepovcpc01} for splines of arbitrary order. 
-
-The NSFDTD formulations given above and in \cite{PukhovJPP99,Vayjcp2011,CowanPRSTAB13,LehePRSTAB13} 
-apply to the Maxwell-Faraday
-equation, while the discretized Maxwell-Ampere equation uses the FDTD
-formulation. Consequently, the charge conserving algorithms developed
-for current deposition \cite{Villasenorcpc92,Esirkepovcpc01} apply
-readily to those NSFDTD-based formulations. More details concerning
-those implementations, including the expressions for the numerical
-dispersion and Courant condition are given 
-in \cite{PukhovJPP99,Vayjcp2011,CowanPRSTAB13,LehePRSTAB13}. 
-
-In the case of the pseudospectral solvers, the current deposition
-algorithm generally does not satisfy the discretized continuity equation
-in Fourier space $\tilde{\rho}^{n+1}=\tilde{\rho}^{n}-i\Delta t\fk\cdot\mathbf{\tilde{J}}^{n+1/2}$.
-In this case, a Boris correction \cite{Birdsalllangdon} can be applied
-in $k$ space in the form $\fe_{c}^{n+1}=\fe^{n+1}-\left(\fk\cdot\fe^{n+1}+i\tilde{\rho}^{n+1}\right)\fkhat/k$,
-where $\fe_{c}$ is the corrected field. Alternatively, a correction
-to the current can be applied (with some similarity to the current
-deposition presented by Morse and Nielson in their potential-based
-model in \cite{Morsenielson1971}) using $\fj_{c}^{n+1/2}=\fj^{n+1/2}-\left[\fk\cdot\fj^{n+1/2}-i\left(\tilde{\rho}^{n+1}-\tilde{\rho}^{n}\right)/\Delta t\right]\fkhat/k$,
-where $\fj_{c}$ is the corrected current. In this case, the transverse
-component of the current is left untouched while the longitudinal
-component is effectively replaced by the one obtained from integration
-of the continuity equation, ensuring that the corrected current satisfies
-the continuity equation. The advantage of correcting the current rather than 
-the electric field is that it is more local and thus more compatible with 
-domain decomposition of the fields for parallel computation \cite{VayJCP2013}.
-
-Alternatively, an exact current deposition can be written for the pseudospectral solvers, following the geometrical interpretation of existing methods in real space \cite{Morsenielson1971,Villasenorcpc92,Esirkepovcpc01}, thereby averaging the currents of the paths following grid lines between positions $(x^n,y^n)$ and $(x^{n+1},y^{n+1})$, which is given in 2D (extension to 3D follows readily) for $k\neq0$ by  \cite{VayJCP2013}:
-%
-\begin{eqnarray}
-\fj^{k\neq0}=\frac{i\mathbf{\tilde{D}}}{\fk}
-\label{Eq_Jdep_1}
-\end{eqnarray}
-with 
-\begin{eqnarray}
-D_x   =  \frac{1}{2\Delta t}\sum_i q_i
-  [\Gamma(x_i^{n+1},y_i^{n+1})-\Gamma(x_i^{n},y_i^{n+1}) \nonumber\\ 
-+\Gamma(x_i^{n+1},y_i^{n})-\Gamma(x_i^{n},y_i^{n})],\\
-D_y   =  \frac{1}{2\Delta t}\sum_i q_i
-  [\Gamma(x_i^{n+1},y_i^{n+1})-\Gamma(x_i^{n+1},y_i^{n}) \nonumber \\
-+\Gamma(x_i^{n},y_i^{n+1})-\Gamma(x_i^{n},y_i^{n})],
-\end{eqnarray}
-where $\Gamma$ is the macro-particle form factor. 
-%
-The contributions for $k=0$ are integrated directly in real space  \cite{VayJCP2013}.
+In general, the field is gathered from the mesh onto the macroparticles
+using splines of the same order as for the current deposition $\mathbf{S}=\left(S_{x},S_{y},S_{z}\right)$.
+Three variations are considered:
+\begin{itemize}
+\item ``momentum conserving'': fields are interpolated from the grid nodes
+to the macroparticles using $\mathbf{S}=\left(S_{nx},S_{ny},S_{nz}\right)$
+for all field components (if the fields are known at staggered positions,
+they are first interpolated to the nodes on an auxiliary grid),
+\item ``energy conserving (or Galerkin)'': fields are interpolated from
+the staggered Yee grid to the macroparticles using $\left(S_{nx-1},S_{ny},S_{nz}\right)$
+for $E_{x}$, $\left(S_{nx},S_{ny-1},S_{nz}\right)$ for $E_{y}$,
+$\left(S_{nx},S_{ny},S_{nz-1}\right)$ for $E_{z}$, $\left(S_{nx},S_{ny-1},S_{nz-1}\right)$
+for $B_{x}$, $\left(S_{nx-1},S_{ny},S_{nz-1}\right)$ for $B{}_{y}$
+and$\left(S_{nx-1},S_{ny-1},S_{nz}\right)$ for $B_{z}$ (if the fields
+are known at the nodes, they are first interpolated to the staggered
+positions on an auxiliary grid),
+\item ``uniform'': fields are interpolated directly form the Yee grid
+to the macroparticles using $\mathbf{S}=\left(S_{nx},S_{ny},S_{nz}\right)$
+for all field components (if the fields are known at the nodes, they
+are first interpolated to the staggered positions on an auxiliary
+grid).
+\end{itemize}
+As shown in \cite{BirdsallLangdon,HockneyEastwoodBook,LewisJCP1972},
+the momentum and energy conserving schemes conserve momentum and energy
+respectively at the limit of infinitesimal time steps and generally
+offer better conservation of the respective quantities for a finite
+time step. The uniform scheme does not conserve momentum nor energy
+in the sense defined for the others but is given for completeness,
+as it has been shown to offer some interesting properties in the modeling
+of relativistically drifting plasmas \cite{GodfreyJCP2013}.


### PR DESCRIPTION
The documentation on field gather currently actually contains a copy-pasted text from the current deposition section. This PR fixes an issue. The new text is from a recent review paper by J.L. Vay and myself.