### PR TITLE
 Fix corner case in photon emission (using lower_bound)

### DIFF
--- a/multi_physics/QED/QED_tests/test_picsar_algo.cpp
+++ b/multi_physics/QED/QED_tests/test_picsar_algo.cpp
@@ -7,8 +7,9 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/test/tools/floating_point_comparison.hpp>
 
-//Force the use of PICSAR implementation of upper_bound for debug purposes
+//Force the use of PICSAR implementation of upper_bound and lower_bound for debug purposes
 #define PXRMP_PICSAR_UPPER_BOUND
+#define PXRMP_PICSAR_LOWER_BOUND
 #include <picsar_qed/utils/picsar_algo.hpp>
 
 #include <array>
@@ -47,6 +48,19 @@ BOOST_AUTO_TEST_CASE( picsar_upper_bound_1 )
     }
 }
 
+// ***Test lower_bound
+
+BOOST_AUTO_TEST_CASE( picsar_lower_bound_1 )
+{
+    const auto arr = std::array<double,5>{0.0, 1.0, 2.0, 3.0, 4.0};
+
+    for (const auto nn : std::vector<double>{-1.,0.,0.1,1,1.1,3.9,4.0,5.0}){
+        BOOST_CHECK_EQUAL(
+            picsar_lower_bound(arr.begin(), arr.end(), nn),
+            std::lower_bound(arr.begin(), arr.end(), nn));
+    }
+}
+
 // ***Test upper_bound_functor
 
 BOOST_AUTO_TEST_CASE( picsar_upper_bound_functor_1 )
@@ -63,6 +77,24 @@ BOOST_AUTO_TEST_CASE( picsar_upper_bound_functor_1 )
 
     }
 }
+
+// ***Test lower_bound_functor
+
+BOOST_AUTO_TEST_CASE( picsar_lower_bound_functor_1 )
+{
+    const auto arr = std::array<double,5>{0.0, 1.0, 2.0, 3.0, 4.0};
+
+    for (const auto nn : std::vector<double>{-1.,0.,0.1,1,1.1,3.9,4.0,5.0}){
+        BOOST_CHECK_EQUAL(
+            picsar_lower_bound_functor(0, arr.size(), nn, [&](size_t i){
+                return arr[i];}),
+            std::distance(
+                arr.begin(),
+                std::lower_bound(arr.begin(), arr.end(), nn)));
+
+    }
+}
+
 
 // ***Test linear_interp
 

--- a/multi_physics/QED/include/picsar_qed/physics/quantum_sync/quantum_sync_engine_tables.hpp
+++ b/multi_physics/QED/include/picsar_qed/physics/quantum_sync/quantum_sync_engine_tables.hpp
@@ -653,7 +653,7 @@ namespace quantum_sync{
                 const auto log_e_chi_part = m_log(e_chi_part);
                 const auto log_prob = m_log(one<RealType>-unf_zero_one_minus_epsi);
 
-                const auto upper_frac_index = utils::picsar_upper_bound_functor(
+                const auto upper_frac_index = utils::picsar_lower_bound_functor(
                     0, m_params.frac_how_many,log_prob,[&](int i){
                         return (m_table.interp_first_coord(
                             log_e_chi_part, i));

--- a/multi_physics/QED/include/picsar_qed/qed_commons.h
+++ b/multi_physics/QED/include/picsar_qed/qed_commons.h
@@ -95,13 +95,16 @@
 
 /**
  * If GPU support is enabled, the library uses an internal, GPU-friendly,
- * implementation of the upper_bound algorithm. For test purposes, this implementation
+ * implementation of the upper_bound and of the lower_bound algorithm.
+ * For test purposes, this implementation
  * can be used also on CPU, instead of the implementation provided by the STL.
  * This can be achieved by doing:
  * #define PXRMP_PICSAR_UPPER_BOUND
+ * #define PXRMP_PICSAR_LOWER_BOUND
  */
 #ifdef PXRMP_WITH_GPU
     #define PXRMP_PICSAR_UPPER_BOUND
+    #define PXRMP_PICSAR_LOWER_BOUND
 #endif
 
 

--- a/multi_physics/QED/include/picsar_qed/utils/picsar_algo.hpp
+++ b/multi_physics/QED/include/picsar_qed/utils/picsar_algo.hpp
@@ -87,7 +87,7 @@ ForwardIt
 picsar_lower_bound
 (ForwardIt first, ForwardIt last, const T& val)
 {
-#ifdef PXRMP_PICSAR_UPPER_BOUND
+#ifdef PXRMP_PICSAR_LOWER_BOUND
 
     size_t count = last-first;
     do{

--- a/multi_physics/QED/include/picsar_qed/utils/picsar_algo.hpp
+++ b/multi_physics/QED/include/picsar_qed/utils/picsar_algo.hpp
@@ -62,6 +62,55 @@ picsar_upper_bound
 }
 
 /**
+* This function returns an iterator pointing
+* to the first element in the range [first,last)
+* which compares not less than val. If no element in the range compares
+* not less than val, the function returns last.
+* If the preprocessor variable PXRMP_PICSAR_LOWER_BOUND
+* is defined, a GPU-compatible version is used. Otherwise,
+* the lower_bound function of the standard template library is used.
+* The choice should be made automatically by the library depending on if
+* the code is compiled for GPU. However, the PICSAR implementation can
+* be forced defining PXRMP_PICSAR_LOWER_BOUND.
+*
+* @tparam ForwardIt the iterator type
+* @tparam T the type of 'val'
+* @param[in] first a ForwardIt pointing to the first element of the container
+* @param[in] last a ForwardIt pointing to the end of the container (i.e. beyond the last element)
+* @param[in] val the value to use to find the lower bound
+* @return a ForwardIt to the lower bound
+*/
+template<typename ForwardIt, typename T>
+PXRMP_GPU_QUALIFIER
+PXRMP_FORCE_INLINE
+ForwardIt
+picsar_lower_bound
+(ForwardIt first, ForwardIt last, const T& val)
+{
+#ifdef PXRMP_PICSAR_UPPER_BOUND
+
+    size_t count = last-first;
+    do{
+        auto it = first;
+        const auto step = count/2;
+        it += step;
+         if (!(val<=*it)){
+             first = ++it;
+             count -= step + 1;
+         }
+         else{
+             count = step;
+         }
+    }while(count>0);
+
+    return first;
+
+#else
+    return std::lower_bound(first, last, val);
+#endif
+}
+
+/**
 * This function returns the value of the
 * the first element in a sequence which compares greater than val.
 * If no element in the range compares greater than val, the function returns last.
@@ -89,6 +138,45 @@ picsar_upper_bound_functor
         const auto step = count/2;
         i += step;
          if (!(val<functor(i))){
+             first = ++i;
+             count -= step + 1;
+         }
+         else{
+             count = step;
+         }
+    }while(count>0);
+
+    return first;
+}
+
+/**
+* This function returns the value of the
+* the first element in a sequence which compares not less than val.
+* If no element in the range compares not less than val, the function returns last.
+* In order to be completely general, the sequence is given by a functor
+* f(int i) --> T res, which should respect the property "res2 >= res1 if i2 >= i1".
+*
+* @tparam T the type of 'val'
+* @tparam Functor the type of Functor
+* @param[in] first the first index (an int)
+* @param[in] last the last index (an int)
+* @param[in] val the value to use to find the lower bound
+* @param[in] functor a functor f(int i) --> T res, respecting "res2 >= res1 if i2 >= i1"
+* @return a ForwardIt to the lower bound
+*/
+template<typename T, typename Functor>
+PXRMP_GPU_QUALIFIER
+PXRMP_FORCE_INLINE
+int
+picsar_lower_bound_functor
+(int first, const int last, const T& val, Functor&& functor)
+{
+    int count = last-first;
+    do{
+        auto i = first;
+        const auto step = count/2;
+        i += step;
+         if (!(val<=functor(i))){
              first = ++i;
              count -= step + 1;
          }


### PR DESCRIPTION
In extremely rare cases, in the function which calculates the properties of quantum synchrotron photons, the quantity log_prob could be exactly zero. In these cases, photons are emitted at the highest possible energy, since their quantum parameter becomes identical to the quantum parameter of the emitting particle. The right behavior should be to find the lowest photon quantum parameter corresponding to a cumulative probability distribution equal to one. 
This PR fixes the issue following @NeilZaim's advice (https://github.com/ECP-WarpX/picsar/pull/31), i.e., by using "lower_bound" instead of "upper_bound" 
