### PR TITLE
Use C++17

### DIFF
--- a/multi_physics/QED/CMakeLists.txt
+++ b/multi_physics/QED/CMakeLists.txt
@@ -31,7 +31,7 @@ option(PXRMP_DPCPP_FIX            "Use cl::sycl::floor cl::sycl::floorf on devic
 add_library(PXRMP_QED INTERFACE)
 add_library(${PROJECT_NAME}::PXRMP_QED ALIAS PXRMP_QED)
 
-target_compile_features(PXRMP_QED INTERFACE cxx_std_14)
+target_compile_features(PXRMP_QED INTERFACE cxx_std_17)
 
 if(PXRMP_QED_OMP)
    find_package(OpenMP REQUIRED)

--- a/multi_physics/QED/python_bindings/pxr_qed.cpp
+++ b/multi_physics/QED/python_bindings/pxr_qed.cpp
@@ -266,16 +266,9 @@ compute_gamma_photon_wrapper(
     const pyArr& px, const pyArr& py, const pyArr& pz,
     const REAL ref_quantity)
 {
-    const REAL
-        *p_px = nullptr, *p_py = nullptr, *p_pz = nullptr;
 
-    size_t how_many = 0;
-
-    std::tie(
-        how_many,
-        p_px, p_py, p_pz) =
-            check_and_get_pointers(
-                px, py, pz);
+    const auto [how_many, p_px, p_py, p_pz] =
+        check_and_get_pointers(px, py, pz);
 
     auto res = pyArr(how_many);
     auto p_res = static_cast<REAL*>(res.request().ptr);

--- a/multi_physics/QED/python_bindings/pxr_qed.cpp
+++ b/multi_physics/QED/python_bindings/pxr_qed.cpp
@@ -273,7 +273,7 @@ compute_gamma_photon_wrapper(
     auto res = pyArr(how_many);
     auto p_res = static_cast<REAL*>(res.request().ptr);
 
-    PXRQEDPY_FOR(how_many, [&](int i){
+    PXRQEDPY_FOR(how_many, [&, p_px=p_px, p_py=p_py, p_pz=p_pz](int i){
         p_res[i] =
             pxr_phys::compute_gamma_photon<REAL, UU>(
                 p_px[i], p_py[i], p_pz[i],


### PR DESCRIPTION
This PR sets the required standard to C++17.
It also replaces an old-style `std::tie(a,b,c)` with much nicer structured bindings `auto [a,b,c]`