### PR TITLE
Fix corner case in Breit-Wheeler table

### DIFF
--- a/multi_physics/QED/include/picsar_qed/physics/breit_wheeler/breit_wheeler_engine_tables.hpp
+++ b/multi_physics/QED/include/picsar_qed/physics/breit_wheeler/breit_wheeler_engine_tables.hpp
@@ -709,10 +709,11 @@ namespace breit_wheeler{
                     one<RealType> - unf_zero_one_minus_epsi;
 
                 const auto upper_frac_index = utils::picsar_upper_bound_functor(
-                    0, m_params.frac_how_many,prob,[&](int i){
+                    0, m_params.frac_how_many-1,prob,[&](int i){
                         return (m_table.interp_first_coord(
                             log_e_chi_phot, i));
                     });
+
                 const auto lower_frac_index = upper_frac_index-1;
 
                 const auto upper_frac = m_table.get_y_coord(upper_frac_index);


### PR DESCRIPTION
I think that we need a "-1" here.  Otherwise, if `unf_zero_one_minus_epsi` is exactly 0.5, then `upper_frac_index` becomes equal to `m_params.frac_how_many`, leading to an out of bound access of the table.
Most likely this issue is currently the reason why the CI-test https://github.com/ECP-WarpX/picsar/runs/5111906999?check_suite_focus=true currently fails