### PR TITLE
Enable santizers checks in CI tests

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,7 +6,7 @@ jobs:
   QED:
     name: QED with tablegen [lib]
     runs-on: ubuntu-20.04
-    env: {CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wunreachable-code"}
+    env: {CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wunreachable-code -fsanitize=address -fsanitize=undefined"}
     steps:
     - uses: actions/checkout@v2
     - name: Dependencies

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -3,7 +3,7 @@ name: macos
 on: [push, pull_request]
 
 env:
-  CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code"
+  CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -fsanitize=address -fsanitize=undefined"
 
 jobs:
   # Build libamrex and all tutorials


### PR DESCRIPTION
This PR enables sanitizers checks in CI tests, including memory access checks. This would have caught the issue fixed in https://github.com/ECP-WarpX/picsar/pull/40