### PR TITLE
[mini-PR] Fix incorrectly set flag in python bindings

### DIFF
--- a/multi_physics/QED/python_bindings/pxr_qed.cpp
+++ b/multi_physics/QED/python_bindings/pxr_qed.cpp
@@ -84,7 +84,7 @@ namespace pxr_sc = picsar::multi_physics::phys::schwinger;
     void PXRQEDPY_FOR(int N, const Func& func){
         for (int i = 0; i < N; ++i) func(i);
     }
-    const auto PXRQEDPY_OPENMP_FLAG = true;
+    const auto PXRQEDPY_OPENMP_FLAG = false;
 #endif
 //___________________________________________________________________________________
 


### PR DESCRIPTION
When python bindings are compiled without OpenMP, the flag `PXRQEDPY_OPENMP_FLAG` must be `false` !