### PR TITLE
Fix: CUDA Compile QED Tables

### DIFF
--- a/multi_physics/QED/include/picsar_qed/physics/quantum_sync/quantum_sync_engine_tabulated_functions.hpp
+++ b/multi_physics/QED/include/picsar_qed/physics/quantum_sync/quantum_sync_engine_tabulated_functions.hpp
@@ -25,6 +25,9 @@
 #include "picsar_qed/math/cmath_overloads.hpp"
 
 #include <algorithm>
+#include <cmath>
+#include <exception>
+#include <limits>
 #include <stdexcept>
 
 namespace picsar{
@@ -73,8 +76,9 @@ namespace quantum_sync{
         return quad_a_inf<RealType>(
             [=](RealType s){
                 using namespace math;
+                using namespace std;
                 if( y ==  zero<RealType>)
-                    return std::numeric_limits<RealType>::infinity();;
+                    return numeric_limits<RealType>::infinity();
                 const auto s2 = s*s;
                 const auto s4 = s2*s2;
                 const auto cc = (one<RealType> +
@@ -106,11 +110,12 @@ namespace quantum_sync{
         const RealType chi_part, const RealType csi) noexcept
     {
         using namespace math;
+        using namespace std;
         if( csi >= one<RealType> || chi_part == zero<RealType> )
             return zero<RealType>;
 
         if (csi == zero<RealType>)
-            return std::numeric_limits<RealType>::infinity();
+            return numeric_limits<RealType>::infinity();
 
         const auto yy = compute_y(chi_part, csi);
         const RealType coeff = m_sqrt(three<>)/(two<>*pi<>);
@@ -118,7 +123,7 @@ namespace quantum_sync{
 
         const auto second_part = (csi*csi/(one<RealType>-csi))*
             k_v(two_thirds<RealType>,yy);
-        if(std::isinf(second_part))
+        if(isinf(second_part))
             return zero<RealType>;
 
         return coeff*csi*(inner + second_part);


### PR DESCRIPTION
This fixed the following issue compiling WarpX on Perlmutter (NERSC):
```
...
/global/homes/a/ahuebl/src/warpx/build_pm/_deps/fetchedpicsar-src/multi_physics/QED/include/picsar_qed/physics/quantum_sync/quantum_sync_engine_tabulated_functions.hpp:86:25: error: 'isinf' was not declared in this scope, and no declarations were found by argument-dependent lookup at the point of instantiation
   86 |                 if(isinf(f1) || isinf(cc))
      |                    ~~~~~^~~~
```
via `cmake -S . -B build_pm -DWarpX_QED_TABLE_GEN=ON`.

Compilers / Dependencies:
- GCC 11.2.0
- ~~CUDA 11.5 / NVCC 11.5.119~~ I saw this with a CPU build
- CMake 3.22.0
- Boost 1.78.0