### PR TITLE
CI: Fix pybind11 pip install

### DIFF
--- a/.github/workflows/dependencies/dependencies.sh
+++ b/.github/workflows/dependencies/dependencies.sh
@@ -18,4 +18,5 @@ sudo apt-get install -y --no-install-recommends \
     g++ gfortran      \
     python3-dev
 
-pip install "pybind11[global]"
+python3 -m pip install -U pip
+python3 -m pip install "pybind11[global]"


### PR DESCRIPTION
Fix the failing CI:
```
Collecting pybind11[global]
  Downloading pybind11-2.9.2-py2.py3-none-any.whl (213 kB)
ERROR: Could not find a version that satisfies the requirement pybind11-global==2.9.2; extra == "global" (from pybind11[global]) (from versions: 2.6.0b1, 2.6.0rc1, 2.6.0rc2, 2.6.0rc3, 2.6.0, 2.6.1, 2.6.2, 2.7.0, 2.7.1, 2.8.0, 2.8.1, 2.9.0, 2.9.1)
ERROR: No matching distribution found for pybind11-global==2.9.2; extra == "global" (from pybind11[global])
```