### PR TITLE
Changes allowing mixed precision compilation in WarpX

### DIFF
--- a/multi_physics/QED/include/picsar_qed/physics/breit_wheeler/breit_wheeler_engine_core.hpp
+++ b/multi_physics/QED/include/picsar_qed/physics/breit_wheeler/breit_wheeler_engine_core.hpp
@@ -207,7 +207,7 @@ namespace breit_wheeler{
             compute_gamma_photon<RealType, unit_system::heaviside_lorentz>(v_mom_photon);
 
         bool is_out = false;
-        const auto chi_ele = ref_pair_prod_table.interp(
+        const RealType chi_ele = ref_pair_prod_table.interp(
                 chi_photon, unf_zero_one_minus_epsi,
                 &is_out);
         const auto chi_pos = chi_photon - chi_ele;

--- a/multi_physics/QED/include/picsar_qed/physics/quantum_sync/quantum_sync_engine_core.hpp
+++ b/multi_physics/QED/include/picsar_qed/physics/quantum_sync/quantum_sync_engine_core.hpp
@@ -208,7 +208,7 @@ namespace quantum_sync{
             compute_gamma_ele_pos<RealType, unit_system::heaviside_lorentz>(v_mom_particle);
 
         bool is_out = false;
-        const auto chi_photon = ref_phot_prod_table.interp(
+        const RealType chi_photon = ref_phot_prod_table.interp(
                 chi_particle, unf_zero_one_minus_epsi,
                 &is_out);
 


### PR DESCRIPTION
These two small changes were needed to allow compilation of WarpX with `USE_SINGLE_PRECISION_PARTICLES=TRUE` and the default 'PRECISION=DOUBLE'.

Is this the best way to fix this? The calls to `interp` in the lines changed are returning doubles so the results were doubles (with auto type). This cascaded down to the line with the multiplication of `heaviside_lorentz_electron_rest_energy`. This failed since the operation `Vector<float>*double` is not implemented. Is there a reason that `interp` is returning a double and not obeying `RealType`?