### PR TITLE
CI: Fix Homebrew (macOS)

### DIFF
--- a/.github/workflows/dependencies/dependencies_mac.sh
+++ b/.github/workflows/dependencies/dependencies_mac.sh
@@ -7,8 +7,11 @@
 
 set -eu -o pipefail
 
+brew unlink gcc
 brew update
 brew install boost
 brew install pybind11
 brew install llvm
 #brew install open-mpi
+brew install libomp
+brew link --force libomp


### PR DESCRIPTION
Unbreak brew.

```
...
-- Detecting CXX compile features - done
CMake Error at /usr/local/Cellar/cmake/3.25.1/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find OpenMP_C (missing: OpenMP_C_FLAGS OpenMP_C_LIB_NAMES)
Call Stack (most recent call first):
  /usr/local/Cellar/cmake/3.25.1/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:600 (_FPHSA_FAILURE_MESSAGE)
  /usr/local/Cellar/cmake/3.25.1/share/cmake/Modules/FindOpenMP.cmake:580 (find_package_handle_standard_args)
  CMakeLists.txt:38 (find_package)


-- Configuring incomplete, errors occurred!
...
```