### PR TITLE
Fix SYCL Include Name

### DIFF
--- a/multi_physics/QED/CMakeLists.txt
+++ b/multi_physics/QED/CMakeLists.txt
@@ -22,7 +22,7 @@ option(PXRMP_QED_TEST             "Build PICSAR QED tests " ${IS_TOPLEVEL})
 option(PXRMP_QED_TOOLS            "Build PICSAR QED tools " ${IS_TOPLEVEL})
 option(PXRMP_QED_PYTHON_BINDINGS  "Build PICSAR QED python bindings " ${IS_TOPLEVEL})
 option(PXRMP_BOOST_TEST_DYN_LINK  "Link against the Boost Unit Test Framework shared library" ON)
-option(PXRMP_DPCPP_FIX            "Use cl::sycl::floor cl::sycl::floorf on device" OFF)
+option(PXRMP_DPCPP_FIX            "Use sycl::floor sycl::floorf on device" OFF)
 option(PXRMP_KOKKOS_EXAMPLE       "Build examples using Kokkos" OFF)
 
 

--- a/multi_physics/QED/include/picsar_qed/math/cmath_overloads.hpp
+++ b/multi_physics/QED/include/picsar_qed/math/cmath_overloads.hpp
@@ -205,7 +205,7 @@ namespace math{
     float m_floor(const float x) noexcept
     {
 #ifdef PXRMP_DPCPP_FIX
-        return cl::sycl::floorf(x);
+        return sycl::floorf(x);
 #else
         return floorf(x);
 #endif
@@ -331,7 +331,7 @@ namespace math{
     RealType m_floor(const RealType x) noexcept
     {
 #ifdef PXRMP_DPCPP_FIX
-        return cl::sycl::floor(x);
+        return sycl::floor(x);
 #else
         return std::floor(x);
 #endif

--- a/multi_physics/QED/include/picsar_qed/math/cmath_overloads.hpp
+++ b/multi_physics/QED/include/picsar_qed/math/cmath_overloads.hpp
@@ -7,7 +7,7 @@
 #include <cmath>
 
 #ifdef PXRMP_DPCPP_FIX
-    #include <CL/sycl.hpp>
+    #include <sycl/sycl.hpp>
 #endif
 
 namespace picsar{


### PR DESCRIPTION
Evolved from `<CL/sycl.hpp>` to `<sycl/sycl.hpp>`.

Fix #52