### PR TITLE
CI: Update macOS Runner (Latest)

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -3,15 +3,13 @@ name: macos
 on: [push, pull_request]
 
 env:
-  CXX:      "/usr/local/opt/llvm/bin/clang++"
-  LDFLAGS:  "-L/usr/local/opt/llvm/lib"
-  CXXFLAGS: "-I/usr/local/opt/llvm/include -Werror -Wshadow -Woverloaded-virtual -Wunreachable-code -fsanitize=address -fsanitize=undefined"
+  CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wunreachable-code -fsanitize=address -fsanitize=undefined"
 
 jobs:
   # Build PICSAR tests, PICSAR python bindings, and Kokkos examples
   tutorials-macos:
     name: QED with tests, python bindings, Kokkos examples
-    runs-on: macos-11
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
     - name: Dependencies
@@ -26,4 +24,4 @@ jobs:
             -DKokkos_ENABLE_OPENMP=ON             \
             -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON
         cmake --build build -j 2
-        cmake --build build --target test
+        ctest --test-dir build --output-on-failure

--- a/multi_physics/QED/QED_tests/test_picsar_tables.cpp
+++ b/multi_physics/QED/QED_tests/test_picsar_tables.cpp
@@ -319,9 +319,9 @@ void check_table_1d(
     const auto v0 = tab.get_val(0);
     const auto v1 = tab.get_val(xsize/2);
     const auto v2 = tab.get_val(xsize-1);
-    BOOST_CHECK_EQUAL(v0, linear_function(x0));
-    BOOST_CHECK_EQUAL(v1, linear_function(x1));
-    BOOST_CHECK_EQUAL(v2, linear_function(x2));
+    BOOST_CHECK_SMALL((linear_function(x0)-v0)/v0, tolerance<double>());
+    BOOST_CHECK_SMALL((linear_function(x1)-v1)/v1, tolerance<double>());
+    BOOST_CHECK_SMALL((linear_function(x2)-v2)/v2, tolerance<double>());
 
     const auto xarr = std::array<double, 5>{x0,x1,x2,x3,x4};
     for (const auto& xx : xarr)
@@ -394,15 +394,15 @@ void check_table_2d(
     const auto v02 = tab.get_val(0, ysize-1);
     const auto v12 = tab.get_val(xsize/2, ysize-1);
     const auto v22 = tab.get_val(xsize-1, ysize-1);
-    BOOST_CHECK_EQUAL(v00, linear_function(x0,y0));
-    BOOST_CHECK_EQUAL(v10, linear_function(x1,y0));
-    BOOST_CHECK_EQUAL(v20, linear_function(x2,y0));
-    BOOST_CHECK_EQUAL(v01, linear_function(x0,y1));
-    BOOST_CHECK_EQUAL(v11, linear_function(x1,y1));
-    BOOST_CHECK_EQUAL(v21, linear_function(x2,y1));
-    BOOST_CHECK_EQUAL(v02, linear_function(x0,y2));
-    BOOST_CHECK_EQUAL(v12, linear_function(x1,y2));
-    BOOST_CHECK_EQUAL(v22, linear_function(x2,y2));
+    BOOST_CHECK_SMALL((linear_function(x0,y0)-v00)/v00, tolerance<double>());
+    BOOST_CHECK_SMALL((linear_function(x1,y0)-v10)/v10, tolerance<double>());
+    BOOST_CHECK_SMALL((linear_function(x2,y0)-v20)/v20, tolerance<double>());
+    BOOST_CHECK_SMALL((linear_function(x0,y1)-v01)/v01, tolerance<double>());
+    BOOST_CHECK_SMALL((linear_function(x1,y1)-v11)/v11, tolerance<double>());
+    BOOST_CHECK_SMALL((linear_function(x2,y1)-v21)/v21, tolerance<double>());
+    BOOST_CHECK_SMALL((linear_function(x0,y2)-v02)/v02, tolerance<double>());
+    BOOST_CHECK_SMALL((linear_function(x1,y2)-v12)/v12, tolerance<double>());
+    BOOST_CHECK_SMALL((linear_function(x2,y2)-v22)/v22, tolerance<double>());
 
     const auto y3 = 0.8569*(y1-y0) + y0;
     const auto y4 = 0.3467*(y2-y1) + y1;

--- a/multi_physics/QED/QED_tests/test_picsar_tables.cpp
+++ b/multi_physics/QED/QED_tests/test_picsar_tables.cpp
@@ -20,10 +20,10 @@ using namespace picsar::multi_physics::containers;
 namespace pxr_ser = picsar::multi_physics::utils::serialization;
 
 //Tolerance for double precision calculations
-const double double_tolerance = 2.0e-12;
+const double double_tolerance = 5.0e-12;
 
 //Tolerance for single precision calculations
-const float float_tolerance = 2.0e-5;
+const float float_tolerance = 5.0e-5;
 
 //Templated tolerance
 template <typename T>

--- a/multi_physics/QED/QED_tests/test_picsar_tables.cpp
+++ b/multi_physics/QED/QED_tests/test_picsar_tables.cpp
@@ -20,10 +20,10 @@ using namespace picsar::multi_physics::containers;
 namespace pxr_ser = picsar::multi_physics::utils::serialization;
 
 //Tolerance for double precision calculations
-const double double_tolerance = 1.0e-12;
+const double double_tolerance = 2.0e-12;
 
 //Tolerance for single precision calculations
-const float float_tolerance = 1.0e-5;
+const float float_tolerance = 2.0e-5;
 
 //Templated tolerance
 template <typename T>

--- a/multi_physics/QED/QED_tests/test_picsar_tables.cpp
+++ b/multi_physics/QED/QED_tests/test_picsar_tables.cpp
@@ -20,10 +20,10 @@ using namespace picsar::multi_physics::containers;
 namespace pxr_ser = picsar::multi_physics::utils::serialization;
 
 //Tolerance for double precision calculations
-const double double_tolerance = 1.0e-11;
+const double double_tolerance = 2.0e-11;
 
 //Tolerance for single precision calculations
-const float float_tolerance = 1.0e-4;
+const float float_tolerance = 2.0e-4;
 
 //Templated tolerance
 template <typename T>

--- a/multi_physics/QED/QED_tests/test_picsar_tables.cpp
+++ b/multi_physics/QED/QED_tests/test_picsar_tables.cpp
@@ -20,10 +20,10 @@ using namespace picsar::multi_physics::containers;
 namespace pxr_ser = picsar::multi_physics::utils::serialization;
 
 //Tolerance for double precision calculations
-const double double_tolerance = 5.0e-12;
+const double double_tolerance = 1.0e-11;
 
 //Tolerance for single precision calculations
-const float float_tolerance = 5.0e-5;
+const float float_tolerance = 1.0e-4;
 
 //Templated tolerance
 template <typename T>

--- a/multi_physics/QED/QED_tests/test_picsar_tables.cpp
+++ b/multi_physics/QED/QED_tests/test_picsar_tables.cpp
@@ -20,10 +20,10 @@ using namespace picsar::multi_physics::containers;
 namespace pxr_ser = picsar::multi_physics::utils::serialization;
 
 //Tolerance for double precision calculations
-const double double_tolerance = 1.0e-10;
+const double double_tolerance = 2.0e-10;
 
 //Tolerance for single precision calculations
-const float float_tolerance = 1.0e-3;
+const float float_tolerance = 2.0e-3;
 
 //Templated tolerance
 template <typename T>

--- a/multi_physics/QED/QED_tests/test_picsar_tables.cpp
+++ b/multi_physics/QED/QED_tests/test_picsar_tables.cpp
@@ -20,10 +20,10 @@ using namespace picsar::multi_physics::containers;
 namespace pxr_ser = picsar::multi_physics::utils::serialization;
 
 //Tolerance for double precision calculations
-const double double_tolerance = 1.0e-9;
+const double double_tolerance = 1.0e-12;
 
 //Tolerance for single precision calculations
-const float float_tolerance = 1.0e-2;
+const float float_tolerance = 1.0e-5;
 
 //Templated tolerance
 template <typename T>

--- a/multi_physics/QED/QED_tests/test_picsar_tables.cpp
+++ b/multi_physics/QED/QED_tests/test_picsar_tables.cpp
@@ -20,10 +20,10 @@ using namespace picsar::multi_physics::containers;
 namespace pxr_ser = picsar::multi_physics::utils::serialization;
 
 //Tolerance for double precision calculations
-const double double_tolerance = 2.0e-10;
+const double double_tolerance = 5.0e-10;
 
 //Tolerance for single precision calculations
-const float float_tolerance = 2.0e-3;
+const float float_tolerance = 5.0e-3;
 
 //Templated tolerance
 template <typename T>

--- a/multi_physics/QED/QED_tests/test_picsar_tables.cpp
+++ b/multi_physics/QED/QED_tests/test_picsar_tables.cpp
@@ -20,10 +20,10 @@ using namespace picsar::multi_physics::containers;
 namespace pxr_ser = picsar::multi_physics::utils::serialization;
 
 //Tolerance for double precision calculations
-const double double_tolerance = 5.0e-10;
+const double double_tolerance = 1.0e-9;
 
 //Tolerance for single precision calculations
-const float float_tolerance = 5.0e-3;
+const float float_tolerance = 1.0e-2;
 
 //Templated tolerance
 template <typename T>

--- a/multi_physics/QED/QED_tests/test_picsar_tables.cpp
+++ b/multi_physics/QED/QED_tests/test_picsar_tables.cpp
@@ -20,10 +20,10 @@ using namespace picsar::multi_physics::containers;
 namespace pxr_ser = picsar::multi_physics::utils::serialization;
 
 //Tolerance for double precision calculations
-const double double_tolerance = 5.0e-11;
+const double double_tolerance = 1.0e-10;
 
 //Tolerance for single precision calculations
-const float float_tolerance = 5.0e-4;
+const float float_tolerance = 1.0e-3;
 
 //Templated tolerance
 template <typename T>

--- a/multi_physics/QED/QED_tests/test_picsar_tables.cpp
+++ b/multi_physics/QED/QED_tests/test_picsar_tables.cpp
@@ -20,10 +20,10 @@ using namespace picsar::multi_physics::containers;
 namespace pxr_ser = picsar::multi_physics::utils::serialization;
 
 //Tolerance for double precision calculations
-const double double_tolerance = 2.0e-11;
+const double double_tolerance = 5.0e-11;
 
 //Tolerance for single precision calculations
-const float float_tolerance = 2.0e-4;
+const float float_tolerance = 5.0e-4;
 
 //Templated tolerance
 template <typename T>


### PR DESCRIPTION
The old `macos-11` image is now removed. Update to running release `macos-latest`.

- [x] `picsar_tables` test: some numerical values vary on near-machine precision but compare without an epsilon