### PR TITLE
Update mu_0, alpha to enforce consistency between constants

### DIFF
--- a/multi_physics/QED/QED_tests/test_picsar_phys_constants.cpp
+++ b/multi_physics/QED/QED_tests/test_picsar_phys_constants.cpp
@@ -51,9 +51,9 @@ void test_case_const_phys()
     const auto exp_vacuum_permittivity =
         static_cast<RealType>(8.8541878188e-12);
     const auto exp_vacuum_permeability =
-        static_cast<RealType>(1.25663706127e-6);
+        static_cast<RealType>(1.2566370612685e-6);
     const auto exp_fine_structure =
-        static_cast<RealType>(0.0072973525643);
+        static_cast<RealType>(0.0072973525643330135);
     const auto exp_eV =
         static_cast<RealType>(1.602176634e-19);
     const auto exp_KeV =

--- a/multi_physics/QED/QED_tests/test_picsar_phys_constants.cpp
+++ b/multi_physics/QED/QED_tests/test_picsar_phys_constants.cpp
@@ -50,8 +50,13 @@ void test_case_const_phys()
         static_cast<RealType>(1.0545718176461565e-34);
     const auto exp_vacuum_permittivity =
         static_cast<RealType>(8.8541878188e-12);
+    // NOTE This is adjusted from the CODATA 2022 value 1.25663706127e-6,
+    // so that the relation between exp_light_speed, exp_vacuum_permittivity,
+    // and exp_vacuum_permeability is exact
     const auto exp_vacuum_permeability =
         static_cast<RealType>(1.2566370612685e-6);
+    // NOTE This is calculated from alpha = mu_0/(4*pi)*q_e*q_e*c/hbar
+    // and differs slightly from the CODATA 2022 value 0.0072973525643
     const auto exp_fine_structure =
         static_cast<RealType>(0.0072973525643330135);
     const auto exp_eV =

--- a/multi_physics/QED/include/picsar_qed/physics/phys_constants.h
+++ b/multi_physics/QED/include/picsar_qed/physics/phys_constants.h
@@ -27,9 +27,14 @@ namespace picsar::multi_physics::phys
     template<typename RealType = double>
     constexpr auto vacuum_permittivity = RealType(8.8541878188e-12);
 
+    // NOTE This is adjusted from the CODATA 2022 value 1.25663706127e-6,
+    // so that the relation between exp_light_speed, exp_vacuum_permittivity,
+    // and exp_vacuum_permeability is exact
     template<typename RealType = double>
     constexpr auto vacuum_permeability = RealType(1.2566370612685e-6);
 
+    // NOTE This is calculated from alpha = mu_0/(4*pi)*q_e*q_e*c/hbar
+    // and differs slightly from the CODATA 2022 value 0.0072973525643
     template<typename RealType = double>
     constexpr auto fine_structure =  RealType(0.0072973525643330135);
 

--- a/multi_physics/QED/include/picsar_qed/physics/phys_constants.h
+++ b/multi_physics/QED/include/picsar_qed/physics/phys_constants.h
@@ -28,10 +28,10 @@ namespace picsar::multi_physics::phys
     constexpr auto vacuum_permittivity = RealType(8.8541878188e-12);
 
     template<typename RealType = double>
-    constexpr auto vacuum_permeability = RealType(1.25663706127e-6);
+    constexpr auto vacuum_permeability = RealType(1.2566370612685e-6);
 
     template<typename RealType = double>
-    constexpr auto fine_structure =  RealType(0.0072973525643);
+    constexpr auto fine_structure =  RealType(0.0072973525643330135);
 
     template<typename RealType = double>
     constexpr auto eV = RealType(elementary_charge<>);
@@ -52,7 +52,7 @@ namespace picsar::multi_physics::phys
     //(unfortunately, sqrt is not constexpr)
     template<typename RealType = double>
     constexpr auto sqrt_4_pi_fine_structure =
-        RealType(0.3028221207683449);
+        RealType(0.3028221207690299);
 
     //
     template<typename RealType = double>


### PR DESCRIPTION
Update the values of the vacuum permeability $\mu_0$ and the fine structure constant $\alpha$ to enforce consistency between constants (e.g., $c^2 = 1/(\epsilon_0 \mu_0)$, etc.), following what is done in https://github.com/BLAST-WarpX/warpx/pull/5661.

I think we should merge #60 first and then rebase here.