### PR TITLE
CI: Upgrade Ubuntu version to 22.04

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   QED:
     name: QED with tests, python bindings, Kokkos examples
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env: {CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wunreachable-code -fsanitize=address -fsanitize=undefined"}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
I noticed in #59 that two CI workflows, `CodeQL / Analyze (cpp)` and `linux / QED with tests, python bindings, Kokkos examples`, fail due to a scheduled Ubuntu 20.04 brownout:
```
This is a scheduled Ubuntu 20.04 brownout. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101
```

Not 100% sure if this can be done separately from #59 or if the two PRs should be merged into one.